### PR TITLE
Parameters is no string array anymore

### DIFF
--- a/Phantasma.API/NexusAPI.cs
+++ b/Phantasma.API/NexusAPI.cs
@@ -437,7 +437,12 @@ namespace Phantasma.API
                 {
                     name = x.name,
                     returnType = x.returnType.ToString(),
-                    parameters = x.parameters.Select(y => y.ToString()).ToArray()
+                    parameters = x.parameters.Select(y => new ABIParameterResult()
+                            {
+                                name = y.name,
+                                type = y.type.ToString()
+
+                            }).ToArray()
                 }).ToArray()
             };
         }
@@ -1328,6 +1333,7 @@ namespace Phantasma.API
             }
 
             var contract = this.Nexus.FindContract(contractName);
+            Console.WriteLine("Contract.ABI::: " + contract.ABI);
             return FillABI(contractName, contract.ABI);
         }
     }

--- a/Phantasma.API/NexusAPI.cs
+++ b/Phantasma.API/NexusAPI.cs
@@ -440,6 +440,7 @@ namespace Phantasma.API
                     parameters = x.parameters.Select(y => new ABIParameterResult()
                             {
                                 name = y.name,
+                                vmtype = y.vmtype.ToString(),
                                 type = y.type.ToString()
 
                             }).ToArray()

--- a/Phantasma.API/Structs.cs
+++ b/Phantasma.API/Structs.cs
@@ -263,6 +263,14 @@ namespace Phantasma.API
         public string[] metadata;
     }
 
+    public struct ABIParameterResult : IAPIResult
+    {
+        [APIDescription("Name of method")]
+        public string name;
+
+        public string type;
+    }
+
     public struct ABIMethodResult : IAPIResult
     {
         [APIDescription("Name of method")]
@@ -271,7 +279,7 @@ namespace Phantasma.API
         public string returnType;
 
         [APIDescription("Type of parameters")]
-        public string[] parameters;
+        public ABIParameterResult[] parameters;
     }
 
     public struct ABIContractResult : IAPIResult

--- a/Phantasma.API/Structs.cs
+++ b/Phantasma.API/Structs.cs
@@ -268,6 +268,8 @@ namespace Phantasma.API
         [APIDescription("Name of method")]
         public string name;
 
+        public string vmtype;
+
         public string type;
     }
 

--- a/Phantasma.Blockchain/Contracts/SmartContract.cs
+++ b/Phantasma.Blockchain/Contracts/SmartContract.cs
@@ -115,11 +115,6 @@ namespace Phantasma.Blockchain.Contracts
                 {
                     var paramType = srcParam.ParameterType;
                     var vmtype = VMObject.GetVMType(paramType);
-                    Console.WriteLine("paramType: " + paramType);
-                    Console.WriteLine("paramTypeName: " + paramType.GetType());
-                    Console.WriteLine("name: " + srcParam.Name);
-                    Console.WriteLine("srcParam: " + srcParam.ToString());
-                    Console.WriteLine("+++++++++++++++++++++++++++++++++++++++++++++++++++");
 
                     if (vmtype != VMType.None)
                     {

--- a/Phantasma.Blockchain/Contracts/SmartContract.cs
+++ b/Phantasma.Blockchain/Contracts/SmartContract.cs
@@ -115,10 +115,15 @@ namespace Phantasma.Blockchain.Contracts
                 {
                     var paramType = srcParam.ParameterType;
                     var vmtype = VMObject.GetVMType(paramType);
+                    Console.WriteLine("paramType: " + paramType);
+                    Console.WriteLine("paramTypeName: " + paramType.GetType());
+                    Console.WriteLine("name: " + srcParam.Name);
+                    Console.WriteLine("srcParam: " + srcParam.ToString());
+                    Console.WriteLine("+++++++++++++++++++++++++++++++++++++++++++++++++++");
 
                     if (vmtype != VMType.None)
                     {
-                        parameters.Add(new ContractParameter(srcParam.Name, vmtype));
+                        parameters.Add(new ContractParameter(srcParam.Name, vmtype, paramType.ToString()));
                     }
                     else
                     {

--- a/Phantasma.VM/Contracts/ContractMethod.cs
+++ b/Phantasma.VM/Contracts/ContractMethod.cs
@@ -9,11 +9,13 @@ namespace Phantasma.VM.Contracts
     public struct ContractParameter
     {
         public readonly string name;
-        public readonly VMType type;
+        public readonly VMType vmtype;
+        public readonly string type;
 
-        public ContractParameter(string name, VMType type)
+        public ContractParameter(string name, VMType vmtype, string type)
         {
             this.name = name;
+            this.vmtype = vmtype;
             this.type = type;
         }
     }
@@ -45,8 +47,9 @@ namespace Phantasma.VM.Contracts
             for (int i = 0; i < len; i++)
             {
                 var pName = reader.ReadVarString();
-                var pType = (VMType)reader.ReadByte();
-                parameters[i] = new ContractParameter(pName, pType);
+                var pVMType = (VMType)reader.ReadByte();
+                var pType = reader.ReadVarString();
+                parameters[i] = new ContractParameter(pName, pVMType, pType);
             }
 
             return new ContractMethod(name, returnType, parameters);
@@ -60,7 +63,8 @@ namespace Phantasma.VM.Contracts
             foreach (var entry in parameters)
             {
                 writer.WriteVarString(entry.name);
-                writer.Write((byte)entry.type);
+                writer.Write((byte)entry.vmtype);
+                writer.WriteVarString(entry.type);
             }
         }
 

--- a/Phantasma.VM/Contracts/ContractMethod.cs
+++ b/Phantasma.VM/Contracts/ContractMethod.cs
@@ -28,7 +28,7 @@ namespace Phantasma.VM.Contracts
         {
             this.name = name;
             this.returnType = returnType;
-            this.parameters = parameters.ToArray();
+            this.parameters = parameters;
         }
 
         public override string ToString()


### PR DESCRIPTION
After the latest change which introduces argument names to the `GetABI` call the parameter list was still a string array, which is not the case anymore.

Before:

```
{"name" : "GetRate","returnType" : "Number","parameters" : ["Phantasma.VM.Contracts.ContractParameter","Phantasma.VM.Contracts.ContractParameter","Phantasma.VM.Contracts.ContractParameter"]}
```

Now:

```
{"name" : "GetRate","returnType" : "Number","parameters" : [{"name" : "fromSymbol","type" : "String"},{"name" : "toSymbol","type" : "String"},{"name" : "amount","type" : "Number"}]}
```