### PR TITLE
Dependencies for LunarParser

### DIFF
--- a/Phantasma.RPC/Phantasma.RPC.csproj
+++ b/Phantasma.RPC/Phantasma.RPC.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LunarLabs.Parser" Version="1.2.6" />
+    <PackageReference Include="LunarLabs.Parser" Version="1.2.7" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This was causing me grief locally on 2017 with a fresh pull and clean - then again it could just be me. Updated the reference in the project file to 1.2.7 instead of 1.2.6. Please review.