### PR TITLE
Make RPC Proxy error response same as BP's

### DIFF
--- a/Phantasma.API/NexusAPI.cs
+++ b/Phantasma.API/NexusAPI.cs
@@ -281,6 +281,24 @@ namespace Phantasma.API
                         {
                             throw new APIException($"Proxy error: {e.Message}");
                         }
+
+                        // Checking if it's a JSON with error inside.
+                        // If so, emulating same error response for Proxy sever as BP sends.
+                        LunarLabs.Parser.DataNode root = null;
+                        try
+                        {
+                            root = JSONReader.ReadFromString(result);
+                        }
+                        catch (Exception e)
+                        {
+                            // It's not JSON, do nothing.
+                        }
+
+                        if (root != null && root.HasNode("error"))
+                        {
+                            var errorDesc = root.GetString("error");
+                            throw new APIException(errorDesc);
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
Currently BP send error this way: {"jsonrpc": "2.0", "error": {"code": -32603, "message": "rejected: expected number for amount @ Runtime_TransferTokens"}, "id": 0}

Poltergeist expects this error representation.

RPC Proxy sends error this way: {"jsonrpc": "2.0", "result": {"error" : "rejected: expected number for amount @ Runtime_TransferTokens"}, "id": 1}

Poltergeist cannot detect it.