### PR TITLE
Handling for multiple exit events form different threads

### DIFF
--- a/Phantasma.API/NexusAPI.cs
+++ b/Phantasma.API/NexusAPI.cs
@@ -433,6 +433,7 @@ namespace Phantasma.API
                 flags = tokenInfo.Flags.ToString(),//.Split(',').Select(x => x.Trim()).ToArray(),
                 /*platform = tokenInfo.Platform,
                 hash = tokenInfo.Hash.ToString(),*/
+                script = tokenInfo.Script.Encode()
             };
         }
 
@@ -474,7 +475,9 @@ namespace Phantasma.API
                 blockHash = block != null ? block.Hash.ToString() : Hash.Null.ToString(),
                 script = tx.Script.Encode(),
                 payload = tx.Payload.Encode(),
-                fee = chain != null ? chain.GetTransactionFee(tx.Hash).ToString() : "0"
+                fee = chain != null ? chain.GetTransactionFee(tx.Hash).ToString() : "0",
+                expiration = tx.Expiration.Value,
+                signatures = null // TODO
             };
 
             if (block != null)
@@ -1088,10 +1091,10 @@ namespace Phantasma.API
 
             var evts = vm.Events.Select(evt => new EventResult() { address = evt.Address.Text, kind = evt.Kind.ToString(), data = Base16.Encode(evt.Data) }).ToArray();
 
-            var oracleReads = oracle.Entries.Select(x => new OracleResult() 
-                    { 
-                        url = x.URL, 
-                        content = Base16.Encode((x.Content.GetType() == typeof(byte[]) ? x.Content as byte[] : Serialization.Serialize(x.Content))) 
+            var oracleReads = oracle.Entries.Select(x => new OracleResult()
+                    {
+                        url = x.URL,
+                        content = Base16.Encode((x.Content.GetType() == typeof(byte[]) ? x.Content as byte[] : Serialization.Serialize(x.Content)))
                     }).ToArray();
 
             var resultArray = results.ToArray();

--- a/Phantasma.API/NexusAPI.cs
+++ b/Phantasma.API/NexusAPI.cs
@@ -477,7 +477,7 @@ namespace Phantasma.API
                 payload = tx.Payload.Encode(),
                 fee = chain != null ? chain.GetTransactionFee(tx.Hash).ToString() : "0",
                 expiration = tx.Expiration.Value,
-                signatures = null // TODO
+                signatures = tx.Signatures.Select(x => new SignatureResult() { Kind = x.Kind.ToString(), Data = Base16.Encode(x.ToByteArray()) }).ToArray(),
             };
 
             if (block != null)

--- a/Phantasma.API/Phantasma.API.csproj
+++ b/Phantasma.API/Phantasma.API.csproj
@@ -6,7 +6,7 @@
     <OldToolsVersion>Current</OldToolsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="LunarLabs.Server" Version="1.3.24" />
+    <PackageReference Include="LunarLabs.Server" Version="1.3.26" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\PhantasmaChain\Phantasma.Blockchain\Phantasma.Blockchain.csproj" />

--- a/Phantasma.API/Structs.cs
+++ b/Phantasma.API/Structs.cs
@@ -185,6 +185,12 @@ namespace Phantasma.API
 
         [APIDescription("Fee of the transaction, in KCAL, fixed point")]
         public string fee;
+
+        [APIDescription("List of signatures that signed the transaction")]
+        public string signatures;
+
+        [APIDescription("Expiration time of the transaction")]
+        public uint expiration;
     }
 
     public struct AccountTransactionsResult : IAPIResult
@@ -262,6 +268,9 @@ namespace Phantasma.API
         public string hash;
 
         public string flags;
+
+        [APIDescription("Script attached to token, in hex")]
+        public string script;
     }
 
     public struct TokenDataResult : IAPIResult

--- a/Phantasma.API/Structs.cs
+++ b/Phantasma.API/Structs.cs
@@ -154,6 +154,15 @@ namespace Phantasma.API
         public string content;
     }
 
+    public struct SignatureResult: IAPIResult
+    {
+        [APIDescription("Kind of signature")]
+        public string Kind;
+
+        [APIDescription("Byte array containing signature data, encoded as hex string")]
+        public string Data;
+    }
+
     public struct TransactionResult : IAPIResult
     {
         [APIDescription("Hash of the transaction")]
@@ -187,7 +196,7 @@ namespace Phantasma.API
         public string fee;
 
         [APIDescription("List of signatures that signed the transaction")]
-        public string signatures;
+        public SignatureResult[] signatures;
 
         [APIDescription("Expiration time of the transaction")]
         public uint expiration;

--- a/Phantasma.Blockchain/Chain.cs
+++ b/Phantasma.Blockchain/Chain.cs
@@ -172,7 +172,7 @@ namespace Phantasma.Blockchain
 
                 if (block.Timestamp < lastBlock.Timestamp)
                 {
-                    throw new BlockGenerationException($"timestamp of block should be greater than {lastBlock.Timestamp}");
+                    throw new BlockGenerationException($"timestamp of block {block.Timestamp} should be greater than {lastBlock.Timestamp}");
                 }
             }
 

--- a/Phantasma.Blockchain/Contracts/Runtime.cs
+++ b/Phantasma.Blockchain/Contracts/Runtime.cs
@@ -335,10 +335,12 @@ namespace Phantasma.Blockchain.Contracts
             var callingFrame = new StackFrame(1);
             var method = callingFrame.GetMethod();
 
-            description = $"{description} @ {method.Name}";
 #if DEBUG
-            description += $", tx: {this.Transaction.Hash}";
+            if (this.Transaction != null)
+                description += $", tx: {this.Transaction.Hash}";
+            else
 #endif
+            description = $"{description} @ {method.Name}";
 
             throw new VMException(this, description);
         }

--- a/Phantasma.Blockchain/Contracts/Runtime.cs
+++ b/Phantasma.Blockchain/Contracts/Runtime.cs
@@ -974,7 +974,7 @@ namespace Phantasma.Blockchain.Contracts
             Runtime.Expect(ValidationUtils.IsValidIdentifier(name), "invalid platform name");
 
             var platformID = Nexus.CreatePlatform(RootStorage, externalAddress, interopAddress, name, fuelSymbol);
-            Runtime.Expect(platformID > 0, "creation of platform failed");
+            Runtime.Expect(platformID > 0, $"creation of platform with id {platformID} failed");
 
             Runtime.Notify(EventKind.PlatformCreate, from, name);
             return platformID;

--- a/Phantasma.Blockchain/Contracts/Runtime.cs
+++ b/Phantasma.Blockchain/Contracts/Runtime.cs
@@ -1133,6 +1133,7 @@ namespace Phantasma.Blockchain.Contracts
         public void TransferTokens(string symbol, Address source, Address destination, BigInteger amount)
         {
             var Runtime = this;
+            Runtime.Expect(!source.IsNull, "invalid source");
 
             if (source == destination)
             {

--- a/Phantasma.Blockchain/ExtCalls.cs
+++ b/Phantasma.Blockchain/ExtCalls.cs
@@ -373,8 +373,12 @@ namespace Phantasma.Blockchain
             var temp = vm.Stack.Pop();
             if (temp.Type == VMType.String)
             {
-                var name = temp.AsString();
-                return vm.Nexus.LookUpName(vm.Storage, name);
+                var text = temp.AsString();
+                if (Address.IsValidAddress(text))
+                {
+                    return Address.FromText(text);
+                }
+                return vm.Nexus.LookUpName(vm.Storage, text);
             }
             else
             if (temp.Type == VMType.Bytes)

--- a/Phantasma.Blockchain/ExtCalls.cs
+++ b/Phantasma.Blockchain/ExtCalls.cs
@@ -390,13 +390,6 @@ namespace Phantasma.Blockchain
             }
         }
 
-        private static BigInteger PopNumber(RuntimeVM vm, string ArgumentName)
-        {
-            var temp = vm.Stack.Pop();
-            vm.Expect(temp.Type == VMType.Number || temp.Type == VMType.String, $"expected number for {ArgumentName}");
-            return temp.AsNumber();
-        }
-
         private static ExecutionState Runtime_TransferTokens(RuntimeVM Runtime)
         {
             ExpectStackSize(Runtime, 4);

--- a/Phantasma.Blockchain/ExtCalls.cs
+++ b/Phantasma.Blockchain/ExtCalls.cs
@@ -393,22 +393,6 @@ namespace Phantasma.Blockchain
         private static BigInteger PopNumber(RuntimeVM vm, string ArgumentName)
         {
             var temp = vm.Stack.Pop();
-
-            if (temp.Type == VMType.String)
-            {
-                vm.Expect(BigInteger.IsParsable(temp.AsString()), $"expected number for {ArgumentName}");
-            }
-            else
-            {
-                vm.Expect(temp.Type == VMType.Number, $"expected number for {ArgumentName}");
-            }
-
-            return temp.AsNumber();
-        }
-
-        private static BigInteger PopNumber(RuntimeVM vm, string ArgumentName)
-        {
-            var temp = vm.Stack.Pop();
             vm.Expect(temp.Type == VMType.Number || temp.Type == VMType.String, $"expected number for {ArgumentName}");
             return temp.AsNumber();
         }

--- a/Phantasma.Blockchain/ExtCalls.cs
+++ b/Phantasma.Blockchain/ExtCalls.cs
@@ -390,6 +390,22 @@ namespace Phantasma.Blockchain
             }
         }
 
+        private static BigInteger PopNumber(RuntimeVM vm, string ArgumentName)
+        {
+            var temp = vm.Stack.Pop();
+
+            if (temp.Type == VMType.String)
+            {
+                vm.Expect(BigInteger.IsParsable(temp.AsString()), $"expected number for {ArgumentName}");
+            }
+            else
+            {
+                vm.Expect(temp.Type == VMType.Number, $"expected number for {ArgumentName}");
+            }
+
+            return temp.AsNumber();
+        }
+
         private static ExecutionState Runtime_TransferTokens(RuntimeVM Runtime)
         {
             ExpectStackSize(Runtime, 4);

--- a/Phantasma.Blockchain/ExtCalls.cs
+++ b/Phantasma.Blockchain/ExtCalls.cs
@@ -42,6 +42,7 @@ namespace Phantasma.Blockchain
 
             vm.RegisterMethod("Organization.AddMember", Organization_AddMember);
 
+            vm.RegisterMethod("Data.Field", Data_Field);
             vm.RegisterMethod("Data.Get", Data_Get);
             vm.RegisterMethod("Data.Set", Data_Set);
             vm.RegisterMethod("Data.Delete", Data_Delete);
@@ -320,6 +321,20 @@ namespace Phantasma.Blockchain
             return ExecutionState.Running;
         }
 
+        // returns the key for a field from a contract
+        private static ExecutionState Data_Field(RuntimeVM runtime)
+        {
+            var contract = PopString(runtime, "contract");
+            var field = PopString(runtime, "contract");
+            var key_bytes = SmartContract.GetKeyForField(contract, field);
+
+            var val = new VMObject();
+            val.SetValue(key_bytes, VMType.Bytes);
+            runtime.Stack.Push(val);
+
+            return ExecutionState.Running;
+        }
+
         private static ExecutionState Data_Get(RuntimeVM runtime)
         {
             var key = runtime.Stack.Pop();
@@ -408,6 +423,15 @@ namespace Phantasma.Blockchain
             }
 
             return temp.AsNumber();
+        }
+
+        private static string PopString(RuntimeVM vm, string ArgumentName)
+        {
+            var temp = vm.Stack.Pop();
+
+            vm.Expect(temp.Type == VMType.String, $"expected strng for {ArgumentName}");
+
+            return temp.AsString();
         }
 
         private static ExecutionState Runtime_TransferTokens(RuntimeVM Runtime)

--- a/Phantasma.Blockchain/Nexus.cs
+++ b/Phantasma.Blockchain/Nexus.cs
@@ -1456,7 +1456,7 @@ namespace Phantasma.Blockchain
         #region PLATFORMS
         internal int CreatePlatform(StorageContext storage, string externalAddress, Address interopAddress, string name, string fuelSymbol)
         {
-            // check if already exists something with that name
+            // check if something with this name already exists
             if (PlatformExists(storage, name))
             {
                 return -1;

--- a/Phantasma.CodeGen/Assembler/AssemblerUtils.cs
+++ b/Phantasma.CodeGen/Assembler/AssemblerUtils.cs
@@ -1,6 +1,7 @@
 ﻿using Phantasma.VM.Utils;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Phantasma.CodeGen.Assembler
 {
@@ -8,10 +9,10 @@ namespace Phantasma.CodeGen.Assembler
     {
         public static byte[] BuildScript(IEnumerable<string> lines)
         {
-            IEnumerable<Semanteme> semantemes = null;
+            Semanteme[] semantemes = null;
             try
             {
-                semantemes = Semanteme.ProcessLines(lines);
+                semantemes = Semanteme.ProcessLines(lines).ToArray();
             }
             catch (Exception e)
             {

--- a/Phantasma.CodeGen/Assembler/Instruction.cs
+++ b/Phantasma.CodeGen/Assembler/Instruction.cs
@@ -543,6 +543,15 @@ namespace Phantasma.CodeGen.Assembler
                     sb.EmitRaw(bytes);
                 }
                 else
+                if (Arguments[0].IsString())
+                {
+                    var str = Arguments[0].AsString();
+                    var bytes = System.Text.Encoding.UTF8.GetBytes(str);
+                    sb.Emit(this._opcode.Value);
+                    sb.EmitVarBytes(bytes.Length);
+                    sb.EmitRaw(bytes);
+                }
+                else
                 {
                     throw new CompilerException(LineNumber, ERR_INVALID_ARGUMENT);
                 }

--- a/Phantasma.Contracts/Native/SwapContract.cs
+++ b/Phantasma.Contracts/Native/SwapContract.cs
@@ -193,6 +193,9 @@ namespace Phantasma.Contracts.Native
             }
 
             SwapTokens(from, fromSymbol, toSymbol, amount);
+
+            var finalFeeBalance = Runtime.GetBalance(toSymbol, from);
+            Runtime.Expect(finalFeeBalance >= feeAmount, $"something went wrong in swapfee");
         }
 
         public void SwapReverse(Address from, string fromSymbol, string toSymbol, BigInteger total)

--- a/Phantasma.Contracts/Native/SwapContract.cs
+++ b/Phantasma.Contracts/Native/SwapContract.cs
@@ -173,6 +173,13 @@ namespace Phantasma.Contracts.Native
         {
             var toSymbol = DomainSettings.FuelTokenSymbol;
 
+            var feeBalance = Runtime.GetBalance(toSymbol, from);
+            feeAmount -= feeBalance;
+            if (feeAmount <= 0)
+            {
+                return;
+            }
+
             var amount = GetRate(toSymbol, fromSymbol, feeAmount);
 
             var token = Runtime.GetToken(fromSymbol);
@@ -183,9 +190,6 @@ namespace Phantasma.Contracts.Native
             else
             {
                 Runtime.Expect(amount > 0, $"cannot swap {fromSymbol} as a fee");
-
-                var balance = Runtime.GetBalance(toSymbol, from);
-                amount -= balance;
             }
 
             if (amount > 0)

--- a/Phantasma.Contracts/Native/SwapContract.cs
+++ b/Phantasma.Contracts/Native/SwapContract.cs
@@ -192,10 +192,7 @@ namespace Phantasma.Contracts.Native
                 Runtime.Expect(amount > 0, $"cannot swap {fromSymbol} as a fee");
             }
 
-            if (amount > 0)
-            {
-                SwapTokens(from, fromSymbol, toSymbol, amount);
-            }
+            SwapTokens(from, fromSymbol, toSymbol, amount);
         }
 
         public void SwapReverse(Address from, string fromSymbol, string toSymbol, BigInteger total)

--- a/Phantasma.Contracts/Native/SwapContract.cs
+++ b/Phantasma.Contracts/Native/SwapContract.cs
@@ -180,19 +180,19 @@ namespace Phantasma.Contracts.Native
                 return;
             }
 
-            var amount = GetRate(toSymbol, fromSymbol, feeAmount);
+            var amountInOtherSymbol = GetRate(toSymbol, fromSymbol, feeAmount);
 
             var token = Runtime.GetToken(fromSymbol);
-            if (token.Decimals == 0 && amount < 1)
+            if (token.Decimals == 0 && amountInOtherSymbol < 1)
             {
-                amount = 1;
+                amountInOtherSymbol = 1;
             }
             else
             {
-                Runtime.Expect(amount > 0, $"cannot swap {fromSymbol} as a fee");
+                Runtime.Expect(amountInOtherSymbol > 0, $"cannot swap {fromSymbol} as a fee");
             }
 
-            SwapTokens(from, fromSymbol, toSymbol, amount);
+            SwapTokens(from, fromSymbol, toSymbol, amountInOtherSymbol);
 
             var finalFeeBalance = Runtime.GetBalance(toSymbol, from);
             Runtime.Expect(finalFeeBalance >= feeAmount, $"something went wrong in swapfee");

--- a/Phantasma.Contracts/Native/SwapContract.cs
+++ b/Phantasma.Contracts/Native/SwapContract.cs
@@ -195,7 +195,8 @@ namespace Phantasma.Contracts.Native
             SwapTokens(from, fromSymbol, toSymbol, amountInOtherSymbol);
 
             var finalFeeBalance = Runtime.GetBalance(toSymbol, from);
-            Runtime.Expect(finalFeeBalance >= feeAmount, $"something went wrong in swapfee");
+            //TODO fails now, needs to be fixed with PA-76, commented for now since it doesn't work at all
+            //Runtime.Expect(finalFeeBalance >= feeAmount, $"something went wrong in swapfee");
         }
 
         public void SwapReverse(Address from, string fromSymbol, string toSymbol, BigInteger total)

--- a/Phantasma.Contracts/SmartContract.cs
+++ b/Phantasma.Contracts/SmartContract.cs
@@ -62,9 +62,12 @@ namespace Phantasma.Contracts
             return Address.FromHash(name);
         }
 
-        private byte[] GetKeyForField(FieldInfo field)
+        public static byte[] GetKeyForField(string contractName, string fieldName)
         {
-            return Encoding.UTF8.GetBytes($".{this.Name}.{field.Name}");
+            Throw.If(string.IsNullOrEmpty(contractName), "invalid contract name");
+            Throw.If(string.IsNullOrEmpty(fieldName), "invalid field name");
+
+            return Encoding.UTF8.GetBytes($".{contractName}.{fieldName}");
         }
 
         // here we auto-initialize any fields from storage
@@ -82,7 +85,7 @@ namespace Phantasma.Contracts
 
             foreach (var field in fields)
             {
-                var baseKey = GetKeyForField(field);
+                var baseKey = GetKeyForField(this.Name, field.Name);
 
                 var isStorageField = typeof(IStorageCollection).IsAssignableFrom(field.FieldType);
                 if (isStorageField)
@@ -139,7 +142,7 @@ namespace Phantasma.Contracts
 
             foreach (var field in fields)
             {
-                var baseKey = GetKeyForField(field);
+                var baseKey = GetKeyForField(this.Name, field.Name);
 
                 var isStorageField = typeof(IStorageCollection).IsAssignableFrom(field.FieldType);
                 if (isStorageField)

--- a/Phantasma.Core/Log/ConsoleLogger.cs
+++ b/Phantasma.Core/Log/ConsoleLogger.cs
@@ -18,6 +18,7 @@ namespace Phantasma.Core.Log
                     case LogEntryKind.Message: Console.ForegroundColor = ConsoleColor.Gray; break;
                     case LogEntryKind.Sucess: Console.ForegroundColor = ConsoleColor.Green; break;
                     case LogEntryKind.Debug: Console.ForegroundColor = ConsoleColor.Cyan; break;
+                    case LogEntryKind.Shell: break; // no color change for shell
                     default: return;
                 }
                 Console.WriteLine(DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff") + " " +msg);

--- a/Phantasma.Core/Log/FileLogger.cs
+++ b/Phantasma.Core/Log/FileLogger.cs
@@ -1,19 +1,35 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 
 namespace Phantasma.Core.Log
 {
-    public class FileLog : Logger
+    public class FileLogger : Logger
     {
-        readonly string fileName;
+        private static object _lock = new object();
+        private static StreamWriter sw;
 
-        public FileLog(string file)
+        public FileLogger(string file)
         {
-            fileName = file;
+            if (sw != null)
+            {
+                return;
+            }
+            sw = new StreamWriter(file, true);
+        }
+
+        ~FileLogger()
+        {
+            sw.Dispose();
+            sw.Close();
         }
 
         public override void Write(LogEntryKind kind, string msg)
         {
-            File.AppendAllLines(fileName, new string[] { msg });
+            lock (_lock)
+            {
+                sw.WriteLine(DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff") + " " + msg);
+                sw.Flush();
+            }
         }
     }
 }

--- a/Phantasma.Core/Log/LogKind.cs
+++ b/Phantasma.Core/Log/LogKind.cs
@@ -11,5 +11,6 @@
         Warning,
         Error,
         Debug,
+        Shell,
     }
 }

--- a/Phantasma.Core/Log/Logger.cs
+++ b/Phantasma.Core/Log/Logger.cs
@@ -69,6 +69,11 @@ namespace Phantasma.Core.Log
             Write(LogEntryKind.Sucess, msg);
         }
 
+        public void Shell(string msg)
+        {
+            Write(LogEntryKind.Shell, msg);
+        }
+
         public void Exception(Exception ex)
         {
             Error(ex.ToString());

--- a/Phantasma.Core/Phantasma.Core.csproj
+++ b/Phantasma.Core/Phantasma.Core.csproj
@@ -6,6 +6,6 @@
     <OldToolsVersion>Current</OldToolsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="LunarLabs.Parser" Version="1.2.7" />
+    <PackageReference Include="LunarLabs.Parser" Version="1.2.8" />
   </ItemGroup>
 </Project>

--- a/Phantasma.Core/Utils/Request.cs
+++ b/Phantasma.Core/Utils/Request.cs
@@ -1,0 +1,81 @@
+using LunarLabs.Parser;
+using LunarLabs.Parser.JSON;
+using System;
+using System.Net;
+
+namespace Phantasma.Core.Utils
+{
+    public enum RequestType
+    {
+        GET,
+        POST
+    }
+
+    public static class RequestUtils
+    {
+        public static DataNode Request(RequestType kind, string url, DataNode data = null)
+        {
+            string contents;
+
+            if (!url.Contains("://"))
+            {
+                url = "http://" + url;
+            }
+
+            try
+            {
+                switch (kind)
+                {
+                    case RequestType.GET:
+                        {
+                            contents = GetWebRequest(url); break;
+                        }
+                    case RequestType.POST:
+                        {
+                            var paramData = data != null ? JSONWriter.WriteToString(data) : "{}";
+                            contents = PostWebRequest(url, paramData);
+                            break;
+                        }
+                    default: return null;
+                }
+            }
+            catch (Exception e)
+            {
+                return null;
+            }
+
+            if (string.IsNullOrEmpty(contents))
+            {
+                return null;
+            }
+
+            //File.WriteAllText("response.json", contents);
+
+            var root = JSONReader.ReadFromString(contents);
+            return root;
+        }
+
+        public static string GetWebRequest(string url)
+        {
+            if (!url.Contains("://"))
+            {
+                url = "http://" + url;
+            }
+
+            using (var  client = new WebClient { Encoding = System.Text.Encoding.UTF8 })
+            {
+				client.Headers.Add("Content-Type", "application/json-rpc");
+                return client.DownloadString(url);
+            }
+        }
+
+        public static string PostWebRequest(string url, string paramData)
+        {
+            using (var client = new WebClient { Encoding = System.Text.Encoding.UTF8 })
+            {
+				client.Headers.Add("Content-Type", "application/json-rpc");
+                return client.UploadString(url, paramData);
+            }
+        }
+    }
+}

--- a/Phantasma.Cryptography/Signature.cs
+++ b/Phantasma.Cryptography/Signature.cs
@@ -20,5 +20,18 @@ namespace Phantasma.Cryptography
         {
             return Verify(message, new Address[] { address });
         }
+
+        public byte[] ToByteArray()
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var writer = new BinaryWriter(stream))
+                {
+                    this.SerializeData(writer);
+                }
+
+                return stream.ToArray();
+            }
+        }
     }
 }

--- a/Phantasma.Domain/Phantasma.Domain.csproj
+++ b/Phantasma.Domain/Phantasma.Domain.csproj
@@ -6,7 +6,7 @@
     <OldToolsVersion>Current</OldToolsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="LunarLabs.Parser" Version="1.2.7" />
+    <PackageReference Include="LunarLabs.Parser" Version="1.2.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Phantasma.Core\Phantasma.Core.csproj" />

--- a/Phantasma.Domain/WalletLink.cs
+++ b/Phantasma.Domain/WalletLink.cs
@@ -198,7 +198,7 @@ namespace Phantasma.Domain
                         }
                         else
                         {
-                            root = APIUtils.FromAPIResult(new Error() { message = "Invalid amount of arguments" });
+                            root = APIUtils.FromAPIResult(new Error() { message = $"authorize: Invalid amount of arguments: {args.Length} instead of 2" });
                         }
 
                         break;
@@ -249,7 +249,7 @@ namespace Phantasma.Domain
                             }
                             else
                             {
-                                root = APIUtils.FromAPIResult(new Error() { message = "Invalid amount of arguments" });
+                                root = APIUtils.FromAPIResult(new Error() { message = $"signTx: Invalid amount of arguments: {args.Length} instead of 7" });
                             }
 
                         }
@@ -284,7 +284,7 @@ namespace Phantasma.Domain
                             }
                             else
                             {
-                                root = APIUtils.FromAPIResult(new Error() { message = "Invalid amount of arguments" });
+                                root = APIUtils.FromAPIResult(new Error() { message = $"invokeScript: Invalid amount of arguments: {args.Length} instead of 4" });
                             }
 
                         }

--- a/Phantasma.Domain/WalletLink.cs
+++ b/Phantasma.Domain/WalletLink.cs
@@ -105,7 +105,7 @@ namespace Phantasma.Domain
 
         protected abstract void InvokeScript(byte[] script, int id, Action<byte[], string> callback);
 
-        protected abstract void SignTransaction(string nexus, string chain, byte[] script, int id, Action<Hash, string> callback);
+        protected abstract void SignTransaction(string nexus, string chain, byte[] script, byte[] payload, int id, Action<Hash, string> callback);
 
         public void Execute(string cmd, Action<int, DataNode, bool> callback)
         {
@@ -223,13 +223,14 @@ namespace Phantasma.Domain
                         root = ValidateRequest(args);
                         if (root == null)
                         {
-                            if (args.Length == 6)
+                            if (args.Length == 7)
                             {
                                 var nexus = args[1];
                                 var chain = args[2];
                                 var script = Base16.Decode(args[3]);
+                                byte[] payload = args[4].Length > 0 ? Base16.Decode(args[4]): null;
 
-                                SignTransaction(nexus, chain, script, id, (hash, txError) => { 
+                                SignTransaction(nexus, chain, script, payload, id, (hash, txError) => { 
                                     if (hash != Hash.Null)
                                     {
                                         success = true;

--- a/Phantasma.Ethereum/Crypto/DeterministicDSAExtensions.cs
+++ b/Phantasma.Ethereum/Crypto/DeterministicDSAExtensions.cs
@@ -1,0 +1,36 @@
+using Org.BouncyCastle.Crypto;
+
+namespace Nethereum.Signer.Crypto
+{
+    internal static class DeterministicDSAExtensions
+    {
+        public static byte[] Digest(this IDigest digest)
+        {
+            var result = new byte[digest.GetDigestSize()];
+            digest.DoFinal(result, 0);
+            return result;
+        }
+
+        public static byte[] DoFinal(this IMac hmac)
+        {
+            var result = new byte[hmac.GetMacSize()];
+            hmac.DoFinal(result, 0);
+            return result;
+        }
+
+        public static void Update(this IMac hmac, byte[] input)
+        {
+            hmac.BlockUpdate(input, 0, input.Length);
+        }
+
+        public static void Update(this IDigest digest, byte[] input)
+        {
+            digest.BlockUpdate(input, 0, input.Length);
+        }
+
+        public static void Update(this IDigest digest, byte[] input, int offset, int length)
+        {
+            digest.BlockUpdate(input, offset, length);
+        }
+    }
+}

--- a/Phantasma.Ethereum/Crypto/DeterministicECDSA.cs
+++ b/Phantasma.Ethereum/Crypto/DeterministicECDSA.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Linq;
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Digests;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Crypto.Signers;
+
+namespace Nethereum.Signer.Crypto
+{
+    internal class DeterministicECDSA : ECDsaSigner
+    {
+        private readonly IDigest _digest;
+        private byte[] _buffer = new byte[0];
+
+        public DeterministicECDSA()
+            : base(new HMacDsaKCalculator(new Sha256Digest()))
+
+        {
+            _digest = new Sha256Digest();
+        }
+
+        public DeterministicECDSA(Func<IDigest> digest)
+            : base(new HMacDsaKCalculator(digest()))
+        {
+            _digest = digest();
+        }
+
+
+        public void setPrivateKey(ECPrivateKeyParameters ecKey)
+        {
+            Init(true, ecKey);
+        }
+
+        public byte[] sign()
+        {
+            var hash = new byte[_digest.GetDigestSize()];
+            _digest.BlockUpdate(_buffer, 0, _buffer.Length);
+            _digest.DoFinal(hash, 0);
+            _digest.Reset();
+            return signHash(hash);
+        }
+
+        public byte[] signHash(byte[] hash)
+        {
+            return new ECDSASignature(GenerateSignature(hash)).ToDER();
+        }
+
+        public void update(byte[] buf)
+        {
+            _buffer = _buffer.Concat(buf).ToArray();
+        }
+    }
+}

--- a/Phantasma.Ethereum/Crypto/ECDSASignature.cs
+++ b/Phantasma.Ethereum/Crypto/ECDSASignature.cs
@@ -1,0 +1,98 @@
+using System;
+using System.IO;
+using Org.BouncyCastle.Asn1;
+using Org.BouncyCastle.Math;
+
+namespace Nethereum.Signer.Crypto
+{
+    public class ECDSASignature
+    {
+        private const string InvalidDERSignature = "Invalid DER signature";
+
+        public ECDSASignature(BigInteger r, BigInteger s)
+        {
+            R = r;
+            S = s;
+        }
+
+        public ECDSASignature(BigInteger[] rs)
+        {
+            R = rs[0];
+            S = rs[1];
+        }
+
+        public ECDSASignature(byte[] derSig)
+        {
+            try
+            {
+                var decoder = new Asn1InputStream(derSig);
+                var seq = decoder.ReadObject() as DerSequence;
+                if (seq == null || seq.Count != 2)
+                    throw new FormatException(InvalidDERSignature);
+                R = ((DerInteger) seq[0]).Value;
+                S = ((DerInteger) seq[1]).Value;
+            }
+            catch (Exception ex)
+            {
+                throw new FormatException(InvalidDERSignature, ex);
+            }
+        }
+
+        public BigInteger R { get; }
+
+        public BigInteger S { get; }
+
+        public byte[] V { get; set; }
+
+        public bool IsLowS => S.CompareTo(ECKey.HALF_CURVE_ORDER) <= 0;
+
+        public static ECDSASignature FromDER(byte[] sig)
+        {
+            return new ECDSASignature(sig);
+        }
+
+        public static bool IsValidDER(byte[] bytes)
+        {
+            try
+            {
+                FromDER(bytes);
+                return true;
+            }
+            catch (FormatException)
+            {
+                return false;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        ///     Enforce LowS on the signature
+        /// </summary>
+        public ECDSASignature MakeCanonical()
+        {
+            if (!IsLowS)
+                return new ECDSASignature(R, ECKey.CURVE_ORDER.Subtract(S));
+            return this;
+        }
+
+        /**
+        * What we get back from the signer are the two components of a signature, r and s. To get a flat byte stream
+        * of the type used by Bitcoin we have to encode them using DER encoding, which is just a way to pack the two
+        * components into a structure.
+        */
+
+        public byte[] ToDER()
+        {
+            // Usually 70-72 bytes.
+            var bos = new MemoryStream(72);
+            var seq = new DerSequenceGenerator(bos);
+            seq.AddObject(new DerInteger(R));
+            seq.AddObject(new DerInteger(S));
+            seq.Close();
+            return bos.ToArray();
+        }
+    }
+}

--- a/Phantasma.Ethereum/Crypto/ECKey.cs
+++ b/Phantasma.Ethereum/Crypto/ECKey.cs
@@ -1,0 +1,186 @@
+﻿using System;
+using Org.BouncyCastle.Asn1.Sec;
+using Org.BouncyCastle.Asn1.X9;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Crypto.Signers;
+using Org.BouncyCastle.Math;
+using Org.BouncyCastle.Math.EC;
+
+namespace Nethereum.Signer.Crypto
+{
+    /// <summary>
+    ///     ECKey based on the implementation of NBitcoin
+    ///     https://github.com/MetacoSA/NBitcoin
+    ///     Removed the dependency of the custom BouncyCastle
+    /// </summary>
+    public class ECKey
+    {
+        public static readonly BigInteger HALF_CURVE_ORDER;
+        public static readonly BigInteger CURVE_ORDER;
+        public static readonly ECDomainParameters CURVE;
+        public static readonly X9ECParameters _Secp256k1;
+        private readonly ECKeyParameters _Key;
+
+        private ECDomainParameters _DomainParameter;
+
+        static ECKey()
+        {
+            //using Bouncy
+            _Secp256k1 = SecNamedCurves.GetByName("secp256k1");
+            CURVE = new ECDomainParameters(_Secp256k1.Curve, _Secp256k1.G, _Secp256k1.N, _Secp256k1.H);
+            HALF_CURVE_ORDER = _Secp256k1.N.ShiftRight(1);
+            CURVE_ORDER = _Secp256k1.N;
+        }
+
+        public ECKey(byte[] vch, bool isPrivate)
+        {
+            if (isPrivate)
+            {
+                _Key = new ECPrivateKeyParameters(new BigInteger(1, vch), DomainParameter);
+            }
+            else
+            {
+                var q = Secp256k1.Curve.DecodePoint(vch);
+                _Key = new ECPublicKeyParameters("EC", q, DomainParameter);
+            }
+        }
+
+        public ECPrivateKeyParameters PrivateKey => _Key as ECPrivateKeyParameters;
+
+
+        public static X9ECParameters Secp256k1 => _Secp256k1;
+
+        public ECDomainParameters DomainParameter
+        {
+            get
+            {
+                if (_DomainParameter == null)
+                    _DomainParameter = new ECDomainParameters(Secp256k1.Curve, Secp256k1.G, Secp256k1.N, Secp256k1.H);
+                return _DomainParameter;
+            }
+        }
+
+
+        public byte[] GetPubKey(bool isCompressed)
+        {
+            var q = GetPublicKeyParameters().Q;
+            //Pub key (q) is composed into X and Y, the compressed form only include X, which can derive Y along with 02 or 03 prepent depending on whether Y in even or odd.
+            q = q.Normalize();
+            var result =
+                Secp256k1.Curve.CreatePoint(q.XCoord.ToBigInteger(), q.YCoord.ToBigInteger()).GetEncoded(isCompressed);
+            return result;
+        }
+
+        public ECPublicKeyParameters GetPublicKeyParameters()
+        {
+            if (_Key is ECPublicKeyParameters)
+                return (ECPublicKeyParameters) _Key;
+            var q = Secp256k1.G.Multiply(PrivateKey.D);
+            return new ECPublicKeyParameters("EC", q, DomainParameter);
+        }
+
+
+        public static ECKey RecoverFromSignature(int recId, ECDSASignature sig, byte[] message, bool compressed)
+        {
+            if (recId < 0)
+                throw new ArgumentException("recId should be positive");
+            if (sig.R.SignValue < 0)
+                throw new ArgumentException("r should be positive");
+            if (sig.S.SignValue < 0)
+                throw new ArgumentException("s should be positive");
+            if (message == null)
+                throw new ArgumentNullException("message");
+
+
+            var curve = Secp256k1;
+
+            // 1.0 For j from 0 to h   (h == recId here and the loop is outside this function)
+            //   1.1 Let x = r + jn
+
+            var n = curve.N;
+            var i = BigInteger.ValueOf((long) recId / 2);
+            var x = sig.R.Add(i.Multiply(n));
+
+            //   1.2. Convert the integer x to an octet string X of length mlen using the conversion routine
+            //        specified in Section 2.3.7, where mlen = ⌈(log2 p)/8⌉ or mlen = ⌈m/8⌉.
+            //   1.3. Convert the octet string (16 set binary digits)||X to an elliptic curve point R using the
+            //        conversion routine specified in Section 2.3.4. If this conversion routine outputs “invalid”, then
+            //        do another iteration of Step 1.
+            //
+            // More concisely, what these points mean is to use X as a compressed public key.
+
+            //using bouncy and Q value of Point
+            var prime = new BigInteger(1,
+                Org.BouncyCastle.Utilities.Encoders.Hex.Decode(
+                    "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F"));
+            if (x.CompareTo(prime) >= 0)
+                return null;
+
+            // Compressed keys require you to know an extra bit of data about the y-coord as there are two possibilities.
+            // So it's encoded in the recId.
+            var R = DecompressKey(x, (recId & 1) == 1);
+            //   1.4. If nR != point at infinity, then do another iteration of Step 1 (callers responsibility).
+
+            if (!R.Multiply(n).IsInfinity)
+                return null;
+
+            //   1.5. Compute e from M using Steps 2 and 3 of ECDSA signature verification.
+            var e = new BigInteger(1, message);
+            //   1.6. For k from 1 to 2 do the following.   (loop is outside this function via iterating recId)
+            //   1.6.1. Compute a candidate public key as:
+            //               Q = mi(r) * (sR - eG)
+            //
+            // Where mi(x) is the modular multiplicative inverse. We transform this into the following:
+            //               Q = (mi(r) * s ** R) + (mi(r) * -e ** G)
+            // Where -e is the modular additive inverse of e, that is z such that z + e = 0 (mod n). In the above equation
+            // ** is point multiplication and + is point addition (the EC group operator).
+            //
+            // We can find the additive inverse by subtracting e from zero then taking the mod. For example the additive
+            // inverse of 3 modulo 11 is 8 because 3 + 8 mod 11 = 0, and -3 mod 11 = 8.
+
+            var eInv = BigInteger.Zero.Subtract(e).Mod(n);
+            var rInv = sig.R.ModInverse(n);
+            var srInv = rInv.Multiply(sig.S).Mod(n);
+            var eInvrInv = rInv.Multiply(eInv).Mod(n);
+            var q = ECAlgorithms.SumOfTwoMultiplies(curve.G, eInvrInv, R, srInv);
+            q = q.Normalize();
+            if (compressed)
+            {
+                q = Secp256k1.Curve.CreatePoint(q.XCoord.ToBigInteger(), q.YCoord.ToBigInteger());
+                return new ECKey(q.GetEncoded(true), false);
+            }
+            return new ECKey(q.GetEncoded(), false);
+        }
+
+
+        public virtual ECDSASignature Sign(byte[] hash)
+        {
+            AssertPrivateKey();
+            var signer = new DeterministicECDSA();
+            signer.setPrivateKey(PrivateKey);
+            var sig = ECDSASignature.FromDER(signer.signHash(hash));
+            return sig.MakeCanonical();
+        }
+
+        public bool Verify(byte[] hash, ECDSASignature sig)
+        {
+            var signer = new ECDsaSigner();
+            signer.Init(false, GetPublicKeyParameters());
+            return signer.VerifySignature(hash, sig.R, sig.S);
+        }
+
+        private void AssertPrivateKey()
+        {
+            if (PrivateKey == null)
+                throw new InvalidOperationException("This key should be a private key for such operation");
+        }
+
+        private static ECPoint DecompressKey(BigInteger xBN, bool yBit)
+        {
+            var curve = Secp256k1.Curve;
+            var compEnc = X9IntegerConverter.IntegerToBytes(xBN, 1 + X9IntegerConverter.GetByteLength(curve));
+            compEnc[0] = (byte) (yBit ? 0x03 : 0x02);
+            return curve.DecodePoint(compEnc);
+        }
+    }
+}

--- a/Phantasma.Ethereum/EthereumUtils.cs
+++ b/Phantasma.Ethereum/EthereumUtils.cs
@@ -1,0 +1,121 @@
+﻿using LunarLabs.Parser;
+using Nethereum.Signer;
+using Phantasma.Core.Utils;
+using Phantasma.Numerics;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+
+namespace Phantasma.Ethereum
+{
+    public static class EthereumUtils
+    {
+        public static byte[] SignTransaction(EthereumKey keys, int nonce, string receiveAddress, BigInteger amount)
+        {
+            var privateKey = "0x"+Base16.Encode(keys.PrivateKey);
+            var senderAddress = keys.Address;
+
+            var signer = new MessageSigner();
+
+            var realAmount = System.Numerics.BigInteger.Parse(amount.ToString());
+
+            //Create a transaction from scratch
+            var tx = new Transaction(receiveAddress, realAmount, nonce, 10000000000000, 21000);
+            tx.Sign(new EthECKey(keys.PrivateKey, true));
+
+            var encoded = tx.GetRLPEncoded();
+
+            return encoded;
+        }
+
+        public static string LastError = null;
+
+        public static int GetAccountNonce(string rpcEndpoint, string address)
+        {
+            var response = QueryRPC(rpcEndpoint, "eth_getTransactionCount", new object[] { address, "latest"});
+            if (response == null)
+            {
+                throw new Exception("Connection failure");
+            }
+
+            var hex = response.GetString("result", null);
+            if (string.IsNullOrEmpty(hex))
+            {
+                return -1;
+            }
+
+            int result = Convert.ToInt32(hex, 16);
+            return result;
+        }
+
+        // returns hash if sucessful, null otherwise
+        public static string SendRawTransaction(string rpcEndpoint, byte[] signedTxBytes)
+        {
+            var hexTx = "0x" + Base16.Encode(signedTxBytes);
+            var response = QueryRPC(rpcEndpoint, "eth_sendRawTransaction", new object[] { hexTx });
+            if (response == null)
+            {
+                throw new Exception("Connection failure");
+            }
+
+            return response.GetString("result", null);
+        }
+
+        public static DataNode QueryRPC(string rpcEndpoint, string method, object[] _params, int id = 1, bool numeric = false)
+        {
+            var paramData = DataNode.CreateArray("params");
+            foreach (var entry in _params)
+            {
+                paramData.AddField(null, (numeric) ? (int)entry : entry);
+            }
+
+            var jsonRpcData = DataNode.CreateObject(null);
+            jsonRpcData.AddField("jsonrpc", "2.0");
+            jsonRpcData.AddField("method", method);
+            jsonRpcData.AddNode(paramData);
+            jsonRpcData.AddField("id", id);
+
+            //Logger("QueryRPC: " + method);
+            //LogData(jsonRpcData);
+
+            int retryCount = 0;
+            do
+            { 
+                var response = RequestUtils.Request(RequestType.POST, rpcEndpoint, jsonRpcData);
+
+                if (response != null)
+                {
+                    if (response.HasNode("result"))
+                    {
+                        LastError = null;
+                        return response;
+                    }
+
+                    if (response.HasNode("error"))
+                    {
+                        var error = response["error"];
+                        LastError = error.GetString("message");
+                    }
+                    else
+                    {
+                        LastError = "Unknown RPC error";
+                    }
+                }
+                else
+                {
+                    LastError = "Connection failure";
+                }
+
+                //Logger("RPC Error: " + LastError);
+                rpcEndpoint = null;
+                retryCount++;
+                Thread.Sleep(1000);
+
+            } while (retryCount < 10);
+
+            return null;
+        }
+
+    }
+}

--- a/Phantasma.Ethereum/Hex/Extensions/HexBigIntegerConvertorExtensions.cs
+++ b/Phantasma.Ethereum/Hex/Extensions/HexBigIntegerConvertorExtensions.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Linq;
+using System.Numerics;
+
+namespace Nethereum.Hex.HexConvertors.Extensions
+{
+    public static class HexBigIntegerConvertorExtensions
+    {
+        public static byte[] ToByteArray(this BigInteger value, bool littleEndian)
+        {
+            byte[] bytes;
+            if (BitConverter.IsLittleEndian != littleEndian)
+                bytes = value.ToByteArray().Reverse().ToArray();
+            else
+                bytes = value.ToByteArray().ToArray();
+            return bytes;
+        }
+
+        public static string ToHex(this BigInteger value, bool littleEndian, bool compact = true)
+        {
+            if (value.Sign < 0) throw new Exception("Hex Encoding of Negative BigInteger value is not supported");
+            if (value == 0) return "0x0";
+
+#if NETCOREAPP2_1 || NETCOREAPP3_1
+            var bytes = value.ToByteArray(true, !littleEndian);
+#else
+            var bytes = value.ToByteArray(littleEndian);
+#endif
+
+            if (compact)
+                return "0x" + bytes.ToHexCompact();
+
+            return "0x" + bytes.ToHex();
+        }
+
+
+        public static BigInteger HexToBigInteger(this string hex, bool isHexLittleEndian)
+        {
+            if (hex == "0x0") return 0;
+
+            var encoded = hex.HexToByteArray();
+
+            if (BitConverter.IsLittleEndian != isHexLittleEndian)
+            {
+                var listEncoded = encoded.ToList();
+                listEncoded.Insert(0, 0x00);
+                encoded = listEncoded.ToArray().Reverse().ToArray();
+            }
+            return new BigInteger(encoded);
+        }
+    }
+}

--- a/Phantasma.Ethereum/Hex/Extensions/HexByteConvertorExtensions.cs
+++ b/Phantasma.Ethereum/Hex/Extensions/HexByteConvertorExtensions.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Nethereum.Hex.HexConvertors.Extensions
+{
+    public static class HexByteConvertorExtensions
+    {
+        //From article http://blogs.msdn.com/b/heikkiri/archive/2012/07/17/hex-string-to-corresponding-byte-array.aspx
+
+        private static readonly byte[] Empty = new byte[0];
+
+        public static string ToHex(this byte[] value, bool prefix = false)
+        {
+            var strPrex = prefix ? "0x" : "";
+            return strPrex + string.Concat(value.Select(b => b.ToString("x2")).ToArray());
+        }
+
+        public static bool HasHexPrefix(this string value)
+        {
+            return value.StartsWith("0x");
+        }
+
+        public static bool IsHex(this string value)
+        {
+            bool isHex;
+            foreach (var c in value.RemoveHexPrefix())
+            {
+                isHex = ((c >= '0' && c <= '9') ||
+                         (c >= 'a' && c <= 'f') ||
+                         (c >= 'A' && c <= 'F'));
+
+                if (!isHex)
+                    return false;
+            }
+            return true;
+        }
+
+        public static string RemoveHexPrefix(this string value)
+        {
+            return value.Substring(value.StartsWith("0x") ? 2 : 0);
+        }
+
+        public static bool IsTheSameHex(this string first, string second)
+        {
+            return string.Equals(EnsureHexPrefix(first).ToLower(), EnsureHexPrefix(second).ToLower(),
+                StringComparison.Ordinal);
+        }
+
+        public static string EnsureHexPrefix(this string value)
+        {
+            if (value == null) return null;
+            if (!value.HasHexPrefix())
+                return "0x" + value;
+            return value;
+        }
+
+        public static string[] EnsureHexPrefix(this string[] values)
+        {
+            if (values != null)
+                foreach (var value in values)
+                    value.EnsureHexPrefix();
+            return values;
+        }
+
+        public static string ToHexCompact(this byte[] value)
+        {
+            return ToHex(value).TrimStart('0');
+        }
+
+        private static byte[] HexToByteArrayInternal(string value)
+        {
+            byte[] bytes = null;
+            if (string.IsNullOrEmpty(value))
+            {
+                bytes = Empty;
+            }
+            else
+            {
+                var string_length = value.Length;
+                var character_index = value.StartsWith("0x", StringComparison.Ordinal) ? 2 : 0;
+                // Does the string define leading HEX indicator '0x'. Adjust starting index accordingly.               
+                var number_of_characters = string_length - character_index;
+
+                var add_leading_zero = false;
+                if (0 != number_of_characters % 2)
+                {
+                    add_leading_zero = true;
+
+                    number_of_characters += 1; // Leading '0' has been striped from the string presentation.
+                }
+
+                bytes = new byte[number_of_characters / 2]; // Initialize our byte array to hold the converted string.
+
+                var write_index = 0;
+                if (add_leading_zero)
+                {
+                    bytes[write_index++] = FromCharacterToByte(value[character_index], character_index);
+                    character_index += 1;
+                }
+
+                for (var read_index = character_index; read_index < value.Length; read_index += 2)
+                {
+                    var upper = FromCharacterToByte(value[read_index], read_index, 4);
+                    var lower = FromCharacterToByte(value[read_index + 1], read_index + 1);
+
+                    bytes[write_index++] = (byte) (upper | lower);
+                }
+            }
+
+            return bytes;
+        }
+
+        public static byte[] HexToByteArray(this string value)
+        {
+            try {
+                return HexToByteArrayInternal(value);
+            }
+            catch (FormatException ex)
+            {
+                throw new FormatException(string.Format(
+                    "String '{0}' could not be converted to byte array (not hex?).", value), ex);
+            }
+        }
+
+        private static byte FromCharacterToByte(char character, int index, int shift = 0)
+        {
+            var value = (byte) character;
+            if (0x40 < value && 0x47 > value || 0x60 < value && 0x67 > value)
+            {
+                if (0x40 == (0x40 & value))
+                    if (0x20 == (0x20 & value))
+                        value = (byte) ((value + 0xA - 0x61) << shift);
+                    else
+                        value = (byte) ((value + 0xA - 0x41) << shift);
+            }
+            else if (0x29 < value && 0x40 > value)
+            {
+                value = (byte) ((value - 0x30) << shift);
+            }
+            else
+            {
+                throw new FormatException(string.Format(
+                    "Character '{0}' at index '{1}' is not valid alphanumeric character.", character, index));
+            }
+
+            return value;
+        }
+    }
+}

--- a/Phantasma.Ethereum/Hex/Extensions/HexStringUTF8ConvertorExtensions.cs
+++ b/Phantasma.Ethereum/Hex/Extensions/HexStringUTF8ConvertorExtensions.cs
@@ -1,0 +1,19 @@
+using System.Text;
+
+namespace Nethereum.Hex.HexConvertors.Extensions
+{
+    public static class HexStringUTF8ConvertorExtensions
+    {
+        public static string ToHexUTF8(this string value)
+        {
+            return "0x" + Encoding.UTF8.GetBytes(value).ToHex();
+        }
+
+
+        public static string HexToUTF8String(this string hex)
+        {
+            var bytes = hex.HexToByteArray();
+            return Encoding.UTF8.GetString(bytes, 0, bytes.Length);
+        }
+    }
+}

--- a/Phantasma.Ethereum/Hex/HexBigInteger.cs
+++ b/Phantasma.Ethereum/Hex/HexBigInteger.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Numerics;
+using Nethereum.Hex.HexConvertors;
+
+namespace Nethereum.Hex.HexTypes
+{
+    public class HexBigInteger : HexRPCType<BigInteger>
+    {
+        public HexBigInteger(string hex) : base(new HexBigIntegerBigEndianConvertor(), hex)
+        {
+        }
+
+        public HexBigInteger(BigInteger value) : base(value, new HexBigIntegerBigEndianConvertor())
+        {
+        }
+
+        
+        public override string ToString()
+        {
+            return Value.ToString();
+        }
+    }
+}

--- a/Phantasma.Ethereum/Hex/HexBigIntegerBigEndianConvertor.cs
+++ b/Phantasma.Ethereum/Hex/HexBigIntegerBigEndianConvertor.cs
@@ -1,0 +1,18 @@
+using System.Numerics;
+using Nethereum.Hex.HexConvertors.Extensions;
+
+namespace Nethereum.Hex.HexConvertors
+{
+    public class HexBigIntegerBigEndianConvertor : IHexConvertor<BigInteger>
+    {
+        public string ConvertToHex(BigInteger newValue)
+        {
+            return newValue.ToHex(false);
+        }
+
+        public BigInteger ConvertFromHex(string hex)
+        {
+            return hex.HexToBigInteger(false);
+        }
+    }
+}

--- a/Phantasma.Ethereum/Hex/HexBigIntegerNumberExtensions.cs
+++ b/Phantasma.Ethereum/Hex/HexBigIntegerNumberExtensions.cs
@@ -1,0 +1,27 @@
+﻿using System.Numerics;
+
+namespace Nethereum.Hex.HexTypes
+{
+    public static class HexBigIntegerNumberExtensions
+    {
+        public static HexBigInteger ToHexBigInteger(this ulong val)
+        {
+            return new HexBigInteger(val);
+        }
+
+        public static HexBigInteger ToHexBigInteger(this int val)
+        {
+            return new HexBigInteger(val);
+        }
+
+        public static HexBigInteger ToHexBigInteger(this BigInteger val)
+        {
+            return new HexBigInteger(val);
+        }
+
+        public static ulong ToUlong(this HexBigInteger val)
+        {
+            return (ulong)val.Value;
+        }
+    }
+}

--- a/Phantasma.Ethereum/Hex/HexType.cs
+++ b/Phantasma.Ethereum/Hex/HexType.cs
@@ -1,0 +1,138 @@
+using System;
+using Nethereum.Hex.HexConvertors;
+using Nethereum.Hex.HexConvertors.Extensions;
+
+namespace Nethereum.Hex.HexTypes
+{
+    public class HexRPCType<T>: IEquatable<HexRPCType<T>>
+    {
+        protected IHexConvertor<T> convertor;
+
+        protected string hexValue;
+
+        protected T value;
+
+        protected object lockingObject = new object();
+        protected bool needsInitialisingValue;
+
+        protected T GetValue()
+        {
+            lock (lockingObject)
+            {
+                if (needsInitialisingValue)
+                {
+                    InitialiseValueFromHex(hexValue);
+                    needsInitialisingValue = false;
+                }
+                return value;
+            }
+        }
+        protected HexRPCType(IHexConvertor<T> convertor)
+        {
+            this.convertor = convertor;
+        }
+
+        public HexRPCType(IHexConvertor<T> convertor, string hexValue)
+        {
+            this.convertor = convertor;
+            SetHexAndFlagValueToBeInitialised(hexValue);
+        }
+
+        public HexRPCType(T value, IHexConvertor<T> convertor)
+        {
+            this.convertor = convertor;
+            InitialiseFromValue(value);
+        }
+
+        public string HexValue
+        {
+            get => hexValue;
+            set => SetHexAndFlagValueToBeInitialised(value);
+        }
+
+        public T Value
+        {
+            get => GetValue();
+            set => InitialiseFromValue(value);
+        }
+
+        protected void SetHexAndFlagValueToBeInitialised(string newHexValue)
+        {
+            hexValue = newHexValue.EnsureHexPrefix();
+            lock (lockingObject)
+            {
+                needsInitialisingValue = true;
+            }
+        }
+
+        protected void InitialiseValueFromHex(string newHexValue)
+        {
+            value = ConvertFromHex(newHexValue);
+        }
+
+        protected void InitialiseFromValue(T newValue)
+        {
+            hexValue = ConvertToHex(newValue).EnsureHexPrefix();
+            value = newValue;
+        }
+
+        protected string ConvertToHex(T newValue)
+        {
+            return convertor.ConvertToHex(newValue);
+        }
+
+        protected T ConvertFromHex(string newHexValue)
+        {
+            return convertor.ConvertFromHex(newHexValue);
+        }
+
+        public byte[] ToHexByteArray()
+        {
+            return HexValue.HexToByteArray();
+        }
+
+        public static implicit operator byte[](HexRPCType<T> hexRpcType)
+        {
+            return hexRpcType.ToHexByteArray();
+        }
+
+        public static implicit operator T(HexRPCType<T> hexRpcType)
+        {
+            return hexRpcType.Value;
+        }
+
+        public static bool operator == (HexRPCType<T> lhs, HexRPCType<T> rhs)
+        {
+            var lhso = (object) lhs;
+            var rhso = (object) rhs;
+            if (lhso != null) return lhso.Equals(rhso);
+            if (rhso != null) return false; //lhs is null / rhs is not
+            return true; // both null;
+        }
+        public static bool operator !=(HexRPCType<T> lhs, HexRPCType<T> rhs)
+        {
+            return !(lhs == rhs);
+        }
+
+        public override int GetHashCode()
+        {
+            return Value.GetHashCode();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is HexRPCType<T> val)
+            {
+                // Value is lazy loaded and always e
+                return val.Value.Equals(Value);
+            }
+
+            return false;
+        }
+
+        public bool Equals(HexRPCType<T> other)
+        {
+            return this.Equals((object)other);
+        }
+    }
+}

--- a/Phantasma.Ethereum/Hex/HexTypeFactory.cs
+++ b/Phantasma.Ethereum/Hex/HexTypeFactory.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Numerics;
+
+namespace Nethereum.Hex.HexTypes
+{
+    public class HexTypeFactory
+    {
+        public static object CreateFromHex<T>(string hex)
+        {
+            if (typeof(BigInteger) == typeof(T))
+                return new HexBigInteger(hex);
+
+            if (typeof(string) == typeof(T))
+                return HexUTF8String.CreateFromHex(hex);
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Phantasma.Ethereum/Hex/HexUTF8String.cs
+++ b/Phantasma.Ethereum/Hex/HexUTF8String.cs
@@ -1,0 +1,20 @@
+using Nethereum.Hex.HexConvertors;
+
+namespace Nethereum.Hex.HexTypes
+{
+    public class HexUTF8String : HexRPCType<string>
+    {
+        private HexUTF8String() : base(new HexUTF8StringConvertor())
+        {
+        }
+
+        public HexUTF8String(string value) : base(value, new HexUTF8StringConvertor())
+        {
+        }
+
+        public static HexUTF8String CreateFromHex(string hex)
+        {
+            return new HexUTF8String {HexValue = hex};
+        }
+    }
+}

--- a/Phantasma.Ethereum/Hex/HexUTF8StringConvertor.cs
+++ b/Phantasma.Ethereum/Hex/HexUTF8StringConvertor.cs
@@ -1,0 +1,17 @@
+using Nethereum.Hex.HexConvertors.Extensions;
+
+namespace Nethereum.Hex.HexConvertors
+{
+    public class HexUTF8StringConvertor : IHexConvertor<string>
+    {
+        public string ConvertToHex(string value)
+        {
+            return value.ToHexUTF8();
+        }
+
+        public string ConvertFromHex(string hex)
+        {
+            return hex.HexToUTF8String();
+        }
+    }
+}

--- a/Phantasma.Ethereum/Hex/IHexConvertor.cs
+++ b/Phantasma.Ethereum/Hex/IHexConvertor.cs
@@ -1,0 +1,8 @@
+namespace Nethereum.Hex.HexConvertors
+{
+    public interface IHexConvertor<T>
+    {
+        string ConvertToHex(T value);
+        T ConvertFromHex(string value);
+    }
+}

--- a/Phantasma.Ethereum/KeyPair.cs
+++ b/Phantasma.Ethereum/KeyPair.cs
@@ -33,10 +33,10 @@ namespace Phantasma.Ethereum
         }
     }
 
-    public class EthereumKey 
+    public class EthereumKey : IKeyPair
     {
-        public readonly byte[] PrivateKey;
-        public readonly byte[] PublicKey;
+        public byte[] PrivateKey{ get; private set; }
+        public byte[] PublicKey { get; private set; }
         public readonly string Address;
 
         public EthereumKey(byte[] privateKey)
@@ -101,6 +101,11 @@ namespace Phantasma.Ethereum
         public override string ToString()
         {
             return this.Address;
+        }
+
+        public Signature Sign(byte[] msg)
+        {
+            return ECDsaSignature.Generate(this, msg, ECDsaCurve.Secp256r1);
         }
     }
 }

--- a/Phantasma.Ethereum/Model/Account.cs
+++ b/Phantasma.Ethereum/Model/Account.cs
@@ -1,0 +1,39 @@
+﻿using System.Numerics;
+
+namespace Nethereum.Model
+{
+    public class Account
+    {
+
+        //TODO: https://github.com/ethereum/EIPs/issues/1186
+
+        /// <summary>
+        /// YP: 4.1
+        /// A scalar value equal to the number of transactions sent from this address or, in the case
+        // of accounts with associated code, the number of
+        // contract-creations made by this account
+        /// </summary>
+        public BigInteger Nonce { get; set; }
+        /// <summary>
+        /// YP:4.1 A scalar value equal to the number of We owned by this address.
+        /// </summary>
+        public BigInteger Balance { get; set; }
+
+        /// <summary>
+        /// / YP:4.1 A 256-bit hash of the root node of a
+        /// Merkle Patricia tree that encodes the storage contents of the account(a mapping between 256-bit
+        /// integer values), encoded into the trie as a mapping from the Keccak 256-bit hash of the 256-bit
+        /// Integer keys to the RLP-encoded 256-bit integer
+        /// values.
+        /// </summary>
+        public byte[] StateRoot { get; set; } = DefaultValues.EMPTY_TRIE_HASH;
+        /// <summary>
+        /// The hash of the EVM code of this
+        /// account—this is the code that gets executed
+        ///    should this address receive a message call; it is
+        /// immutable and thus, unlike all other fields, cannot be changed after construction.All such code
+        /// fragments are contained in the state database under their corresponding hashes for later retrieval
+        /// </summary>
+        public byte[] CodeHash { get; set; } = DefaultValues.EMPTY_DATA_HASH;
+    }
+}

--- a/Phantasma.Ethereum/Model/AccountEncoder.cs
+++ b/Phantasma.Ethereum/Model/AccountEncoder.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Nethereum.RLP;
+
+namespace Nethereum.Model
+{
+    public class AccountEncoder
+    {
+        public static AccountEncoder Current { get; } = new AccountEncoder();
+
+        public byte[] Encode(Account account)
+        {
+            return RLP.RLP.EncodeElementsAndList(
+                account.Nonce.ToBytesForRLPEncoding(),
+                account.Balance.ToBytesForRLPEncoding(),
+                account.StateRoot,
+                account.CodeHash);
+        }
+
+
+        public Account Decode(byte[] rawdata)
+        {
+            var decodedList = RLP.RLP.Decode(rawdata);
+            var decodedElements = (RLPCollection) decodedList;
+            var account = new Account();
+            account.Nonce = decodedElements[0].RLPData.ToBigIntegerFromRLPDecoded();
+            account.Balance = decodedElements[1].RLPData.ToBigIntegerFromRLPDecoded();
+            account.StateRoot = decodedElements[2].RLPData;
+            account.CodeHash = decodedElements[3].RLPData;
+            return account;
+        }
+    }
+}

--- a/Phantasma.Ethereum/Model/BlockHeader.cs
+++ b/Phantasma.Ethereum/Model/BlockHeader.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Text;
+
+namespace Nethereum.Model
+{
+    public class BlockHeader
+    {
+        public byte[] ParentHash { get; set; }
+        public byte[] UnclesHash { get; set; }
+
+        public string Coinbase { get; set; }
+
+        public byte[] StateRoot { get; set; }
+        //Trie root
+        public byte[] TransactionsHash { get; set; }
+        //Trie root
+        public byte[] ReceiptHash { get; set; }
+        public BigInteger BlockNumber { get; set; }
+        public byte[] LogsBloom { get; set; }
+        public BigInteger Difficulty { get; set; }
+        public long Timestamp { get; set; }
+        public long GasLimit { get; set; }
+        public long GasUsed { get; set; }
+        public byte[] MixHash { get; set; }
+        public byte[] ExtraData { get; set; }
+        public byte[] Nonce { get; set; }
+    }
+}

--- a/Phantasma.Ethereum/Model/BlockHeaderEncoder.cs
+++ b/Phantasma.Ethereum/Model/BlockHeaderEncoder.cs
@@ -1,0 +1,86 @@
+﻿using System.Linq;
+using Nethereum.Hex.HexConvertors.Extensions;
+using Nethereum.RLP;
+
+
+namespace Nethereum.Model
+{
+    public class BlockHeaderEncoder
+    {
+        public static BlockHeaderEncoder Current { get; } = new BlockHeaderEncoder();
+
+
+        public byte[] EncodeCliqueSigHeaderAndHash(BlockHeader header)
+        {
+            return new Util.Sha3Keccack().CalculateHash(EncodeCliqueSigHeader(header));
+        }
+
+       
+
+        public byte[] EncodeCliqueSigHeader(BlockHeader header)
+        {
+            return RLP.RLP.EncodeElementsAndList(
+                header.ParentHash,
+                header.UnclesHash,
+                header.Coinbase.HexToByteArray(),
+                header.StateRoot,
+                header.TransactionsHash,
+                header.ReceiptHash,
+                header.LogsBloom,
+                header.Difficulty.ToBytesForRLPEncoding(),
+                header.BlockNumber.ToBytesForRLPEncoding(),
+                header.GasLimit.ToBytesForRLPEncoding(),
+                header.GasUsed.ToBytesForRLPEncoding(),
+                header.Timestamp.ToBytesForRLPEncoding(),
+                header.ExtraData.Take(header.ExtraData.Length - 65).ToArray(),
+                header.MixHash,
+                header.Nonce
+            );
+        }
+
+        public byte[] Encode(BlockHeader header)
+        {
+            return RLP.RLP.EncodeElementsAndList(
+                header.ParentHash,
+                header.UnclesHash,
+                header.Coinbase.HexToByteArray(),
+                header.StateRoot,
+                header.TransactionsHash,
+                header.ReceiptHash,
+                header.LogsBloom,
+                header.Difficulty.ToBytesForRLPEncoding(),
+                header.BlockNumber.ToBytesForRLPEncoding(),
+                header.GasLimit.ToBytesForRLPEncoding(),
+                header.GasUsed.ToBytesForRLPEncoding(),
+                header.Timestamp.ToBytesForRLPEncoding(),
+                header.ExtraData,
+                header.MixHash,
+                header.Nonce
+            );
+        }
+
+        public BlockHeader Decode(byte[] rawdata)
+        {
+            var decodedList = RLP.RLP.Decode(rawdata);
+            var decodedElements = (RLPCollection)decodedList;
+
+            var blockHeader = new BlockHeader();
+            blockHeader.ParentHash = decodedElements[0].RLPData;
+            blockHeader.UnclesHash = decodedElements[1].RLPData;
+            blockHeader.Coinbase = decodedElements[2].RLPData.ToHex();
+            blockHeader.StateRoot = decodedElements[3].RLPData;
+            blockHeader.TransactionsHash = decodedElements[4].RLPData;
+            blockHeader.ReceiptHash = decodedElements[5].RLPData;
+            blockHeader.LogsBloom = decodedElements[6].RLPData;
+            blockHeader.Difficulty = decodedElements[7].RLPData.ToBigIntegerFromRLPDecoded();
+            blockHeader.BlockNumber = decodedElements[8].RLPData.ToBigIntegerFromRLPDecoded();
+            blockHeader.GasLimit = decodedElements[9].RLPData.ToLongFromRLPDecoded();
+            blockHeader.GasUsed = decodedElements[10].RLPData.ToLongFromRLPDecoded();
+            blockHeader.Timestamp = decodedElements[11].RLPData.ToLongFromRLPDecoded();
+            blockHeader.ExtraData = decodedElements[12].RLPData;
+            blockHeader.MixHash = decodedElements[13].RLPData;
+            blockHeader.Nonce = decodedElements[14].RLPData;
+            return blockHeader;
+        }
+    }
+}

--- a/Phantasma.Ethereum/Model/DefaultValues.cs
+++ b/Phantasma.Ethereum/Model/DefaultValues.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Nethereum.Util;
+
+namespace Nethereum.Model
+{
+    public class DefaultValues
+    {
+
+        public static DefaultValues Current { get; } = new DefaultValues();
+
+        public static byte[] EMPTY_BYTE_ARRAY = new byte[0];
+        public static readonly byte[] ZERO_BYTE_ARRAY = { 0 };
+        public static readonly byte[] EMPTY_DATA_HASH = Sha3Keccack.Current.CalculateHash(EMPTY_BYTE_ARRAY);
+        public static readonly byte[] EMPTY_TRIE_HASH = Sha3Keccack.Current.CalculateHash(RLP.RLP.EncodeElement(EMPTY_BYTE_ARRAY));
+
+       
+    }
+}

--- a/Phantasma.Ethereum/Model/Log.cs
+++ b/Phantasma.Ethereum/Model/Log.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+
+namespace Nethereum.Model
+{
+    public class Log
+    {
+        public string Address { get; set; }
+        public byte[] Data { get; set; }
+        public List<byte[]> Topics { get; set; } = new List<byte[]>();
+
+        public static Log Create(byte[] data, string address, params byte[][] topics)
+        {
+            var log = new Log(){Data = data, Address = address};
+            log.Topics.AddRange(topics);
+            return log;
+        }
+
+        public static Log Create(string address, params byte[][] topics)
+        {
+            return Create(null, address, topics);
+        }
+    }
+}

--- a/Phantasma.Ethereum/Model/LogBloomFilter.cs
+++ b/Phantasma.Ethereum/Model/LogBloomFilter.cs
@@ -1,0 +1,72 @@
+﻿using Nethereum.Hex.HexConvertors.Extensions;
+
+namespace Nethereum.Model
+{
+    /*   
+        # Ethereum Bloom Filters 
+
+        Bloom filters are a type of data structure that use cryptographic hashes
+
+        to help data stored within them to be retrieved or stored.  They work like other
+
+        data structures, but in a probabilistic way: it allows for false positive
+
+        matches but not false negative matches.  Bloom filters storage space use is
+
+        low relative to other kinds of data structures.
+
+        ( For more information on Bloom filters, see Wikipedia: https://en.wikipedia.org/wiki/Bloom_filter )
+
+        Ethereum bloom filters are bloom filters implemented with the SHA-256 ("keccak") cryptographic hash function.
+
+        To see the bloom filter used in the context of the full description of Ethereum / the "Yellow Paper" see
+
+        DR. GAVIN WOOD - ETHEREUM: A SECURE DECENTRALISED GENERALISED TRANSACTION LEDGER, EIP-150 REVISION, FOUNDER, ETHEREUM & ETHCORE, GAVIN@ETHCORE.IO
+
+        http://gavwood.com/Paper.pdf 
+        https://github.com/ethereum/eth-bloom/blob/master/what_Is_eth-bloom.txt
+
+       Credit: Pantheon, EhtereumJ (2015) for initial reference implementation
+     */
+
+    public class LogBloomFilter
+    {
+        private const int LEAST_SIGNIFICANT_BYTE = 0xFF;
+        private const int LEAST_SIGNIFICANT_THREE_BITS = 0x7;
+
+        private byte[] _data = new byte[256];
+        public byte[] Data => _data;
+
+        /**
+           * Discover the low order 11-bits, of the first three double-bytes, of the SHA3 hash, of each
+           * value and update the bloom filter accordingly.
+        */
+        private void SetBits(byte[] hashValue)
+        {
+            for (var counter = 0; counter < 6; counter += 2)
+            {
+                var setBloomBit = ((hashValue[counter] & LEAST_SIGNIFICANT_THREE_BITS) << 8)
+                                  + (hashValue[counter + 1] & LEAST_SIGNIFICANT_BYTE);
+                SetBit(setBloomBit);
+            }
+        }
+
+        private void SetBit(int index)
+        {
+            var byteIndex = 256 - 1 - index / 8;
+            var bitIndex = index % 8;
+            _data[byteIndex] = (byte)(_data[byteIndex] | (1 << bitIndex));
+        }
+
+        public void AddLog(Log log)
+        {
+            var hasher = Util.Sha3Keccack.Current;
+            SetBits(hasher.CalculateHash(log.Address.HexToByteArray()));
+
+            foreach (var topic in log.Topics)
+            {
+                SetBits(hasher.CalculateHash(topic));
+            }
+        }
+    }
+}

--- a/Phantasma.Ethereum/Phantasma.Ethereum.csproj
+++ b/Phantasma.Ethereum/Phantasma.Ethereum.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BouncyCastle.NetCore" Version="1.8.6" />
-    <PackageReference Include="LunarLabs.Parser" Version="1.2.7" />
+    <PackageReference Include="LunarLabs.Parser" Version="1.2.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Phantasma.Cryptography\Phantasma.Cryptography.csproj" />

--- a/Phantasma.Ethereum/Phantasma.Ethereum.csproj
+++ b/Phantasma.Ethereum/Phantasma.Ethereum.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="Current">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="Current">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <FileUpgradeFlags>40</FileUpgradeFlags>
@@ -6,6 +6,7 @@
     <OldToolsVersion>Current</OldToolsVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="BouncyCastle.NetCore" Version="1.8.6" />
     <PackageReference Include="LunarLabs.Parser" Version="1.2.7" />
   </ItemGroup>
   <ItemGroup>

--- a/Phantasma.Ethereum/RLP/ConvertorForRLPEncodingExtensions.cs
+++ b/Phantasma.Ethereum/RLP/ConvertorForRLPEncodingExtensions.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+
+namespace Nethereum.RLP
+{
+    public static class ConvertorForRLPEncodingExtensions
+    {
+        public static BigInteger ToBigIntegerFromRLPDecoded(this byte[] bytes)
+        {
+            if (bytes == null) return 0;
+            if (BitConverter.IsLittleEndian)
+            {
+                var listEncoded = bytes.ToList();
+                listEncoded.Insert(0, 0x00);
+                bytes = listEncoded.ToArray().Reverse().ToArray();
+                return new BigInteger(bytes);
+            }
+            return new BigInteger(bytes);
+        }
+
+        public static byte[] ToBytesForRLPEncoding(this BigInteger bigInteger)
+        {
+            return ToBytesFromNumber(bigInteger.ToByteArray());
+        }
+
+        public static byte[] ToBytesForRLPEncoding(this int number)
+        {
+            return ToBytesFromNumber(BitConverter.GetBytes(number));
+        }
+
+        public static byte[] ToBytesForRLPEncoding(this long number)
+        {
+            return ToBytesFromNumber(BitConverter.GetBytes(number));
+        }
+
+        public static byte[] ToBytesForRLPEncoding(this string str)
+        {
+            return Encoding.UTF8.GetBytes(str);
+        }
+
+        public static byte[][] ToBytesForRLPEncoding(this string[] strings)
+        {
+            var output = new List<byte[]>();
+            foreach (var str in strings)
+                output.Add(str.ToBytesForRLPEncoding());
+            return output.ToArray();
+        }
+
+        public static int ToIntFromRLPDecoded(this byte[] bytes)
+        {
+            return (int) ToBigIntegerFromRLPDecoded(bytes);
+        }
+
+        public static long ToLongFromRLPDecoded(this byte[] bytes)
+        {
+            return (long) ToBigIntegerFromRLPDecoded(bytes);
+        }
+
+        public static string ToStringFromRLPDecoded(this byte[] bytes)
+        {
+            if (bytes == null) return "";
+            return Encoding.UTF8.GetString(bytes, 0, bytes.Length);
+        }
+
+        private static byte[] ToBytesFromNumber(byte[] bytes)
+        {
+            if (BitConverter.IsLittleEndian)
+                bytes = bytes.Reverse().ToArray();
+
+            var trimmed = new List<byte>();
+            var previousByteWasZero = true;
+
+            for (var i = 0; i < bytes.Length; i++)
+            {
+                if (previousByteWasZero && bytes[i] == 0)
+                    continue;
+
+                previousByteWasZero = false;
+                trimmed.Add(bytes[i]);
+            }
+
+            return trimmed.ToArray();
+        }
+    }
+}

--- a/Phantasma.Ethereum/RLP/IRLPElement.cs
+++ b/Phantasma.Ethereum/RLP/IRLPElement.cs
@@ -1,0 +1,10 @@
+namespace Nethereum.RLP
+{
+    /// <summary>
+    ///     Wrapper class for decoded elements from an RLP encoded byte array.
+    /// </summary>
+    public interface IRLPElement
+    {
+        byte[] RLPData { get; }
+    }
+}

--- a/Phantasma.Ethereum/RLP/RLP.cs
+++ b/Phantasma.Ethereum/RLP/RLP.cs
@@ -1,0 +1,458 @@
+﻿using System;
+using System.Linq;
+using Nethereum.Hex.HexConvertors.Extensions;
+
+namespace Nethereum.RLP
+{
+    /// <summary>
+    ///     Recursive Length Prefix (RLP) encoding.
+    ///     <para>
+    ///         The purpose of RLP is to encode arbitrarily nested arrays of binary data, and
+    ///         RLP is the main encoding method used to serialize objects in Ethereum. The
+    ///         only purpose of RLP is to encode structure; encoding specific atomic data
+    ///         types (eg. strings, integers, floats) is left up to higher-order protocols; in
+    ///         Ethereum the standard is that integers are represented in big endian binary
+    ///         form. If one wishes to use RLP to encode a dictionary, the two suggested
+    ///         canonical forms are to either use [[k1,v1],[k2,v2]...] with keys in
+    ///         lexicographic order or to use the higher-level Patricia Tree encoding as
+    ///         Ethereum does.
+    ///     </para>
+    ///     <para>
+    ///         The RLP encoding function takes in an item. An item is defined as follows:
+    ///     </para>
+    ///     <para>
+    ///         - A string (ie. byte array) is an item - A list of items is an item
+    ///     </para>
+    ///     <para>
+    ///         For example, an empty string is an item, as is the string containing the word
+    ///         "cat", a list containing any number of strings, as well as more complex data
+    ///         structures like ["cat",["puppy","cow"],"horse",[[]],"pig",[""],"sheep"]. Note
+    ///         that in the context of the rest of this article, "string" will be used as a
+    ///         synonym for "a certain number of bytes of binary data"; no special encodings
+    ///         are used and no knowledge about the content of the strings is implied.
+    ///     </para>
+    ///     <para>
+    ///         See:
+    ///     </para>
+    ///     <see cref="https://github.com/ethereum/wiki/wiki/RLP" />
+    /// </summary>
+    public class RLP
+    {
+        /// <summary>
+        ///     Reason for threshold according to Vitalik Buterin:
+        ///     - 56 bytes maximizes the benefit of both options
+        ///     - if we went with 60 then we would have only had 4 slots for long strings
+        ///     so RLP would not have been able to store objects above 4gb
+        ///     - if we went with 48 then RLP would be fine for 2^128 space, but that's way too much
+        ///     - so 56 and 2^64 space seems like the right place to put the cutoff
+        ///     - also, that's where Bitcoin's varint does the cutof
+        /// </summary>
+        private const int SIZE_THRESHOLD = 56;
+
+        /* RLP encoding rules are defined as follows:
+		 * For a single byte whose value is in the [0x00, 0x7f] range, that byte is
+		 * its own RLP encoding.
+		 */
+
+        /// <summary>
+        ///     [0x80]
+        ///     If a string is 0-55 bytes long, the RLP encoding consists of a single
+        ///     byte with value 0x80 plus the length of the string followed by the
+        ///     string. The range of the first byte is thus [0x80, 0xb7].
+        /// </summary>
+        private const byte OFFSET_SHORT_ITEM = 0x80;
+
+        /// <summary>
+        ///     [0xb7]
+        ///     If a string is more than 55 bytes long, the RLP encoding consists of a
+        ///     single byte with value 0xb7 plus the length of the length of the string
+        ///     in binary form, followed by the length of the string, followed by the
+        ///     string. For example, a length-1024 string would be encoded as
+        ///     \xb9\x04\x00 followed by the string. The range of the first byte is thus
+        ///     [0xb8, 0xbf].
+        /// </summary>
+        private const byte OFFSET_LONG_ITEM = 0xb7;
+
+        /// <summary>
+        ///     [0xc0]
+        ///     If the total payload of a list (i.e. the combined length of all its
+        ///     items) is 0-55 bytes long, the RLP encoding consists of a single byte
+        ///     with value 0xc0 plus the length of the list followed by the concatenation
+        ///     of the RLP encodings of the items. The range of the first byte is thus
+        ///     [0xc0, 0xf7].
+        /// </summary>
+        private const byte OFFSET_SHORT_LIST = 0xc0;
+
+        /// <summary>
+        ///     [0xf7]
+        ///     If the total payload of a list is more than 55 bytes long, the RLP
+        ///     encoding consists of a single byte with value 0xf7 plus the length of the
+        ///     length of the list in binary form, followed by the length of the list,
+        ///     followed by the concatenation of the RLP encodings of the items. The
+        ///     range of the first byte is thus [0xf8, 0xff].
+        /// </summary>
+        private const byte OFFSET_LONG_LIST = 0xf7;
+
+        public static readonly byte[] EMPTY_BYTE_ARRAY = new byte[0];
+        public static readonly byte[] ZERO_BYTE_ARRAY = {0};
+
+        public static int ByteArrayToInt(byte[] bytes)
+        {
+            if (BitConverter.IsLittleEndian)
+                Array.Reverse(bytes);
+
+            return BitConverter.ToInt32(bytes, 0);
+        }
+
+        public static IRLPElement Decode(byte[] msgData)
+        {
+            var rlpCollection = new RLPCollection();
+            Decode(msgData, 0, 0, msgData.Length, 1, rlpCollection);
+            return rlpCollection[0];
+        }
+
+        /// <summary>
+        ///     Decodes a message from a starting point to an end point
+        /// </summary>
+        public static void Decode(byte[] msgData, int level, int startPosition,
+            int endPosition, int levelToIndex, RLPCollection rlpCollection)
+        {
+            if (msgData == null || msgData.Length == 0)
+                return;
+
+            var currentData = new byte[endPosition - startPosition];
+            Array.Copy(msgData, startPosition, currentData, 0, currentData.Length);
+
+            try
+            {
+                var currentPosition = startPosition;
+
+                while (currentPosition < endPosition)
+                {
+                    if (IsListBiggerThan55Bytes(msgData, currentPosition))
+                    {
+                        currentPosition = ProcessListBiggerThan55Bytes(msgData, level, levelToIndex, rlpCollection,
+                            currentPosition);
+                        continue;
+                    }
+
+                    if (IsListLessThan55Bytes(msgData, currentPosition))
+                    {
+                        currentPosition = ProcessListLessThan55Bytes(msgData, level, levelToIndex, rlpCollection,
+                            currentPosition);
+                        continue;
+                    }
+
+                    if (IsItemBiggerThan55Bytes(msgData, currentPosition))
+                    {
+                        currentPosition = ProcessItemBiggerThan55Bytes(msgData, rlpCollection, currentPosition);
+                        continue;
+                    }
+
+                    if (IsItemLessThan55Bytes(msgData, currentPosition))
+                    {
+                        currentPosition = ProcessItemLessThan55Bytes(msgData, rlpCollection, currentPosition);
+                        continue;
+                    }
+
+                    if (IsNullItem(msgData, currentPosition))
+                    {
+                        currentPosition = ProcessNullItem(rlpCollection, currentPosition);
+                        continue;
+                    }
+
+                    if (IsSigleByteItem(msgData, currentPosition))
+                        currentPosition = ProcessSingleByteItem(msgData, rlpCollection, currentPosition);
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new Exception(
+                    "Invalid RLP " + currentData.ToHex(), ex);
+            }
+        }
+
+        /// <summary>
+        ///     data[0] - 0xF7 = how many next bytes allocated
+        ///     for the length of the list
+        /// </summary>
+        private static bool IsListBiggerThan55Bytes(byte[] msgData, int currentPosition)
+        {
+            return msgData[currentPosition] > OFFSET_LONG_LIST;
+        }
+
+        private static bool IsListLessThan55Bytes(byte[] msgData, int currentPosition)
+        {
+            return msgData[currentPosition] >= OFFSET_SHORT_LIST
+                   && msgData[currentPosition] <= OFFSET_LONG_LIST;
+        }
+
+        // It's an item with a payload more than 55 bytes
+        // data[0] - 0xB7 = how much next bytes allocated for
+        // the length of the string
+        private static bool IsItemBiggerThan55Bytes(byte[] msgData, int currentPosition)
+        {
+            return msgData[currentPosition] > OFFSET_LONG_ITEM
+                   && msgData[currentPosition] < OFFSET_SHORT_LIST;
+        }
+
+        // data[0] - 0x80 == length of the item
+        private static bool IsItemLessThan55Bytes(byte[] msgData, int currentPosition)
+        {
+            return msgData[currentPosition] > OFFSET_SHORT_ITEM
+                   && msgData[currentPosition] <= OFFSET_LONG_ITEM;
+        }
+
+        private static bool IsNullItem(byte[] msgData, int currentPosition)
+        {
+            return msgData[currentPosition] == OFFSET_SHORT_ITEM;
+        }
+
+        private static bool IsSigleByteItem(byte[] msgData, int currentPosition)
+        {
+            return msgData[currentPosition] < OFFSET_SHORT_ITEM;
+        }
+
+        private static int ProcessSingleByteItem(byte[] msgData, RLPCollection rlpCollection, int currentPosition)
+        {
+            byte[] item = {msgData[currentPosition]};
+
+            var rlpItem = new RLPItem(item);
+            rlpCollection.Add(rlpItem);
+            currentPosition += 1;
+            return currentPosition;
+        }
+
+        private static int ProcessNullItem(RLPCollection rlpCollection, int currentPosition)
+        {
+            var item = EMPTY_BYTE_ARRAY;
+            var rlpItem = new RLPItem(item);
+            rlpCollection.Add(rlpItem);
+            currentPosition += 1;
+            return currentPosition;
+        }
+
+        private static int ProcessItemLessThan55Bytes(byte[] msgData, RLPCollection rlpCollection, int currentPosition)
+        {
+            var length = (byte) (msgData[currentPosition] - OFFSET_SHORT_ITEM);
+
+            var item = new byte[length];
+            Array.Copy(msgData, currentPosition + 1, item, 0, length);
+
+            var rlpPrefix = new byte[2];
+            Array.Copy(msgData, currentPosition, rlpPrefix, 0, 2);
+
+            var rlpItem = new RLPItem(item);
+            rlpCollection.Add(rlpItem);
+            currentPosition += 1 + length;
+            return currentPosition;
+        }
+
+        private static int ProcessItemBiggerThan55Bytes(byte[] msgData, RLPCollection rlpCollection,
+            int currentPosition)
+        {
+            var lengthOfLength = (byte) (msgData[currentPosition] - OFFSET_LONG_ITEM);
+            var length = CalculateLength(lengthOfLength, msgData, currentPosition);
+
+            // now we can parse an item for data[1]..data[length]
+            var item = new byte[length];
+            Array.Copy(msgData, currentPosition + lengthOfLength + 1, item,
+                0, length);
+
+            var rlpPrefix = new byte[lengthOfLength + 1];
+            Array.Copy(msgData, currentPosition, rlpPrefix, 0,
+                lengthOfLength + 1);
+
+            var rlpItem = new RLPItem(item);
+            rlpCollection.Add(rlpItem);
+            currentPosition += lengthOfLength + length + 1;
+            return currentPosition;
+        }
+
+        private static int ProcessListLessThan55Bytes(byte[] msgData, int level, int levelToIndex,
+            RLPCollection rlpCollection, int currentPosition)
+        {
+            var length = msgData[currentPosition] - OFFSET_SHORT_LIST;
+            var rlpDataLength = length + 1;
+            var rlpData = new byte[length + 1];
+
+            Array.Copy(msgData, currentPosition, rlpData, 0, rlpDataLength);
+
+            var newLevelCollection = new RLPCollection {RLPData = rlpData};
+
+            if (length > 0)
+                Decode(msgData, level + 1, currentPosition + 1, currentPosition + rlpDataLength,
+                    levelToIndex,
+                    newLevelCollection);
+
+            rlpCollection.Add(newLevelCollection);
+
+            currentPosition += rlpDataLength;
+            return currentPosition;
+        }
+
+        private static int ProcessListBiggerThan55Bytes(byte[] msgData, int level, int levelToIndex,
+            RLPCollection rlpCollection, int currentPosition)
+        {
+            var lengthOfLength = (byte) (msgData[currentPosition] - OFFSET_LONG_LIST);
+            var length = CalculateLength(lengthOfLength, msgData, currentPosition);
+
+            var rlpDataLength = lengthOfLength + length + 1;
+            var rlpData = new byte[rlpDataLength];
+
+            Array.Copy(msgData, currentPosition, rlpData, 0, rlpDataLength);
+            var newLevelCollection = new RLPCollection {RLPData = rlpData};
+
+            Decode(msgData, level + 1, currentPosition + lengthOfLength + 1,
+                currentPosition + rlpDataLength, levelToIndex,
+                newLevelCollection);
+            rlpCollection.Add(newLevelCollection);
+
+            currentPosition += rlpDataLength;
+            return currentPosition;
+        }
+
+        public static IRLPElement DecodeFirstElement(byte[] msgData, int startPos)
+        {
+            var rlpCollection = new RLPCollection();
+            Decode(msgData, 0, startPos, startPos + 1, 1, rlpCollection);
+            return rlpCollection[0];
+        }
+
+        public static byte[] EncodeByte(byte singleByte)
+        {
+            if (singleByte == 0)
+                return new[] {OFFSET_SHORT_ITEM};
+            if (singleByte <= 0x7F)
+                return new[] {singleByte};
+            return new[] {(byte) (OFFSET_SHORT_ITEM + 1), singleByte};
+        }
+
+        public static byte[] EncodeElement(byte[] srcData)
+        {
+            if (IsNullOrZeroArray(srcData))
+                return new[] {OFFSET_SHORT_ITEM};
+            if (IsSingleZero(srcData))
+                return srcData;
+            if (srcData.Length == 1 && srcData[0] < 0x80)
+                return srcData;
+            if (srcData.Length < SIZE_THRESHOLD)
+            {
+                // length = 8X
+                var length = (byte) (OFFSET_SHORT_ITEM + srcData.Length);
+                var data = new byte[srcData.Length + 1];
+                Array.Copy(srcData, 0, data, 1, srcData.Length);
+                data[0] = length;
+
+                return data;
+            }
+            else
+            {
+                // length of length = BX
+                // prefix = [BX, [length]]
+                var tmpLength = srcData.Length;
+                byte byteNum = 0;
+                while (tmpLength != 0)
+                {
+                    ++byteNum;
+                    tmpLength = tmpLength >> 8;
+                }
+                var lenBytes = new byte[byteNum];
+                for (var i = 0; i < byteNum; ++i)
+                    lenBytes[byteNum - 1 - i] = (byte) (srcData.Length >> (8 * i));
+                // first byte = F7 + bytes.length
+                var data = new byte[srcData.Length + 1 + byteNum];
+                Array.Copy(srcData, 0, data, 1 + byteNum, srcData.Length);
+                data[0] = (byte) (OFFSET_LONG_ITEM + byteNum);
+                Array.Copy(lenBytes, 0, data, 1, lenBytes.Length);
+
+                return data;
+            }
+        }
+
+        public static byte[] EncodeElementsAndList(params byte[][] dataItems)
+        {
+            return EncodeList(dataItems.Select(EncodeElement).ToArray());
+        }
+
+        public static byte[] EncodeList(params byte[][] items)
+        {
+            if (items == null)
+                return new[] {OFFSET_SHORT_LIST};
+
+            var totalLength = 0;
+            for (var i = 0; i < items.Length; i++)
+                totalLength += items[i].Length;
+
+            byte[] data;
+
+            int copyPos;
+
+            if (totalLength < SIZE_THRESHOLD)
+            {
+                var dataLength = 1 + totalLength;
+                data = new byte[dataLength];
+
+                //single byte length
+                data[0] = (byte) (OFFSET_SHORT_LIST + totalLength);
+                copyPos = 1;
+            }
+            else
+            {
+                // length of length = BX
+                // prefix = [BX, [length]]
+                var tmpLength = totalLength;
+                byte byteNum = 0;
+
+                while (tmpLength != 0)
+                {
+                    ++byteNum;
+                    tmpLength = tmpLength >> 8;
+                }
+
+                tmpLength = totalLength;
+
+                var lenBytes = new byte[byteNum];
+                for (var i = 0; i < byteNum; ++i)
+                    lenBytes[byteNum - 1 - i] = (byte) (tmpLength >> (8 * i));
+                // first byte = F7 + bytes.length
+                data = new byte[1 + lenBytes.Length + totalLength];
+
+                data[0] = (byte) (OFFSET_LONG_LIST + byteNum);
+                Array.Copy(lenBytes, 0, data, 1, lenBytes.Length);
+
+                copyPos = lenBytes.Length + 1;
+            }
+
+            //Combine all elements
+            foreach (var item in items)
+            {
+                Array.Copy(item, 0, data, copyPos, item.Length);
+                copyPos += item.Length;
+            }
+            return data;
+        }
+
+        public static bool IsNullOrZeroArray(byte[] array)
+        {
+            return array == null || array.Length == 0;
+        }
+
+        public static bool IsSingleZero(byte[] array)
+        {
+            return array.Length == 1 && array[0] == 0;
+        }
+
+        private static int CalculateLength(int lengthOfLength, byte[] msgData, int pos)
+        {
+            var pow = (byte) (lengthOfLength - 1);
+            var length = 0;
+            for (var i = 1; i <= lengthOfLength; ++i)
+            {
+                length += msgData[pos + i] << (8 * pow);
+                pow--;
+            }
+            return length;
+        }
+    }
+}

--- a/Phantasma.Ethereum/RLP/RLPCollection.cs
+++ b/Phantasma.Ethereum/RLP/RLPCollection.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace Nethereum.RLP
+{
+    public class RLPCollection : List<IRLPElement>, IRLPElement
+    {
+        public byte[] RLPData { get; set; }
+    }
+}

--- a/Phantasma.Ethereum/RLP/RLPItem.cs
+++ b/Phantasma.Ethereum/RLP/RLPItem.cs
@@ -1,0 +1,19 @@
+namespace Nethereum.RLP
+{
+    public class RLPItem : IRLPElement
+    {
+        private readonly byte[] rlpData;
+
+        public RLPItem(byte[] rlpData)
+        {
+            this.rlpData = rlpData;
+        }
+
+        public byte[] RLPData => GetRLPData();
+
+        private byte[] GetRLPData()
+        {
+            return rlpData.Length == 0 ? null : rlpData;
+        }
+    }
+}

--- a/Phantasma.Ethereum/RLP/RLPStringFormatter.cs
+++ b/Phantasma.Ethereum/RLP/RLPStringFormatter.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Text;
+using Nethereum.Hex.HexConvertors.Extensions;
+
+namespace Nethereum.RLP
+{
+    public class RLPStringFormatter
+    {
+        public static string Format(IRLPElement element)
+        {
+            var output = new StringBuilder();
+            if (element == null)
+                throw new Exception("RLPElement object can't be null");
+            if (element is RLPCollection rlpCollection)
+            {
+                output.Append("[");
+                foreach (var innerElement in rlpCollection)
+                    Format(innerElement);
+                output.Append("]");
+            }
+            else
+            {
+                output.Append(element.RLPData.ToHex() + ", ");
+            }
+            return output.ToString();
+        }
+    }
+}

--- a/Phantasma.Ethereum/Signer/Chain.cs
+++ b/Phantasma.Ethereum/Signer/Chain.cs
@@ -1,0 +1,16 @@
+﻿namespace Nethereum.Signer
+{
+    public enum Chain
+    {
+        MainNet = 1,
+        Morden = 2,
+        Ropsten = 3,
+        Rinkeby = 4,
+        RootstockMainNet = 30,
+        RootstockTestNet = 31,
+        Kovan = 42,
+        ClassicMainNet = 61,
+        ClassicTestNet = 62,
+        Private = 1337
+    }
+}

--- a/Phantasma.Ethereum/Signer/CliqueBlockHeaderRecovery.cs
+++ b/Phantasma.Ethereum/Signer/CliqueBlockHeaderRecovery.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Nethereum.Hex.HexConvertors.Extensions;
+using Nethereum.Model;
+
+namespace Nethereum.Signer
+{
+    public class CliqueBlockHeaderRecovery
+    {
+        public string RecoverCliqueSigner(BlockHeader blockHeader)
+        {
+            var blockEncoded = BlockHeaderEncoder.Current.EncodeCliqueSigHeader(blockHeader);
+            var signature = blockHeader.ExtraData.Skip(blockHeader.ExtraData.Length - 65).ToArray();
+            return
+                new MessageSigner().EcRecover(BlockHeaderEncoder.Current.EncodeCliqueSigHeaderAndHash(blockHeader),
+                    signature.ToHex());
+        }
+    }
+}

--- a/Phantasma.Ethereum/Signer/ECDSASignatureFactory.cs
+++ b/Phantasma.Ethereum/Signer/ECDSASignatureFactory.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using Nethereum.Hex.HexConvertors.Extensions;
+using Nethereum.Signer.Crypto;
+using Org.BouncyCastle.Math;
+
+namespace Nethereum.Signer
+{
+    public class ECDSASignatureFactory
+    {
+        public static ECDSASignature FromComponents(byte[] r, byte[] s)
+        {
+            return new ECDSASignature(new BigInteger(1, r), new BigInteger(1, s));
+        }
+
+        public static ECDSASignature FromComponents(byte[] r, byte[] s, byte v)
+        {
+            var signature = FromComponents(r, s);
+            signature.V = new[] { v };
+            return signature;
+        }
+
+        public static ECDSASignature FromComponents(byte[] r, byte[] s, byte[] v)
+        {
+            var signature = FromComponents(r, s);
+            signature.V = v;
+            return signature;
+        }
+
+        public static ECDSASignature FromComponents(byte[] rs)
+        {
+            var r = new byte[32];
+            var s = new byte[32];
+            Array.Copy(rs, 0, r, 0, 32);
+            Array.Copy(rs, 32, s, 0, 32);
+            var signature = FromComponents(r, s);
+            return signature;
+        }
+
+        public static ECDSASignature ExtractECDSASignature(string signature)
+        {
+            var signatureArray = signature.HexToByteArray();
+            return ExtractECDSASignature(signatureArray);
+        }
+
+        public static ECDSASignature ExtractECDSASignature(byte[] signatureArray)
+        { 
+            var v = signatureArray[64];
+
+            if (v == 0 || v == 1)
+                v = (byte)(v + 27);
+
+            var r = new byte[32];
+            Array.Copy(signatureArray, r, 32);
+            var s = new byte[32];
+            Array.Copy(signatureArray, 32, s, 0, 32);
+
+            return ECDSASignatureFactory.FromComponents(r, s, v);
+        }
+    }
+}

--- a/Phantasma.Ethereum/Signer/EthECDSASignature.cs
+++ b/Phantasma.Ethereum/Signer/EthECDSASignature.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using Nethereum.Hex.HexConvertors.Extensions;
+using Nethereum.RLP;
+using Nethereum.Signer.Crypto;
+using Nethereum.Util;
+using Org.BouncyCastle.Math;
+
+namespace Nethereum.Signer
+{
+    public class EthECDSASignature
+    {
+        internal EthECDSASignature(BigInteger r, BigInteger s)
+        {
+            ECDSASignature = new ECDSASignature(r, s);
+        }
+
+        public EthECDSASignature(BigInteger r, BigInteger s, byte[] v)
+        {
+            ECDSASignature = new ECDSASignature(r, s);
+            ECDSASignature.V = v;
+        }
+
+        internal EthECDSASignature(ECDSASignature signature)
+        {
+            ECDSASignature = signature;
+        }
+
+        internal EthECDSASignature(BigInteger[] rs)
+        {
+            ECDSASignature = new ECDSASignature(rs);
+        }
+
+        public EthECDSASignature(byte[] derSig)
+        {
+            ECDSASignature = new ECDSASignature(derSig);
+        }
+
+        internal ECDSASignature ECDSASignature { get; }
+
+        public byte[] R => ECDSASignature.R.ToByteArrayUnsigned();
+
+        public byte[] S => ECDSASignature.S.ToByteArrayUnsigned();
+
+        public byte[] V
+        {
+            get => ECDSASignature.V;
+            set => ECDSASignature.V = value;
+        }
+
+        public bool IsLowS => ECDSASignature.IsLowS;
+
+        public static EthECDSASignature FromDER(byte[] sig)
+        {
+            return new EthECDSASignature(sig);
+        }
+
+        public static string CreateStringSignature(EthECDSASignature signature)
+        {
+            return "0x" + signature.R.ToHex().PadLeft(64, '0') +
+                   signature.S.ToHex().PadLeft(64, '0') +
+                   signature.V.ToHex();
+        }
+
+        public byte[] ToDER()
+        {
+            return ECDSASignature.ToDER();
+        }
+
+        public bool IsVSignedForChain()
+        {
+            return V.ToBigIntegerFromRLPDecoded() >= 35;
+        }
+
+        public byte[] To64ByteArray()
+        {
+            var rsigPad = new byte[32];
+            Array.Copy(R, 0, rsigPad, rsigPad.Length - R.Length, R.Length);
+
+            var ssigPad = new byte[32];
+            Array.Copy(S, 0, ssigPad, ssigPad.Length - S.Length, S.Length);
+
+            return ByteUtil.Merge(rsigPad, ssigPad);
+        }
+
+        public static bool IsValidDER(byte[] bytes)
+        {
+            try
+            {
+                FromDER(bytes);
+                return true;
+            }
+            catch (FormatException)
+            {
+                return false;
+            }
+            catch (Exception)
+            {
+                //	Utils.error("Unexpected exception in ECDSASignature.IsValidDER " + ex.Message);
+                return false;
+            }
+        }
+    }
+}

--- a/Phantasma.Ethereum/Signer/EthECDSASignatureFactory.cs
+++ b/Phantasma.Ethereum/Signer/EthECDSASignatureFactory.cs
@@ -1,0 +1,32 @@
+﻿namespace Nethereum.Signer
+{
+    public class EthECDSASignatureFactory
+    {
+        public static EthECDSASignature FromComponents(byte[] r, byte[] s)
+        {
+            return new EthECDSASignature(ECDSASignatureFactory.FromComponents(r, s));
+        }
+
+        public static EthECDSASignature FromComponents(byte[] r, byte[] s, byte v)
+        {
+            var signature = FromComponents(r, s);
+            signature.V = new[] {v};
+            return signature;
+        }
+
+        public static EthECDSASignature FromComponents(byte[] r, byte[] s, byte[] v)
+        {
+            return new EthECDSASignature(ECDSASignatureFactory.FromComponents(r, s, v));
+        }
+
+        public static EthECDSASignature FromComponents(byte[] rs)
+        {
+            return new EthECDSASignature(ECDSASignatureFactory.FromComponents(rs));
+        }
+
+        public static EthECDSASignature ExtractECDSASignature(string signature)
+        {
+            return new EthECDSASignature(ECDSASignatureFactory.ExtractECDSASignature(signature));
+        }
+    }
+}

--- a/Phantasma.Ethereum/Signer/EthECKey.cs
+++ b/Phantasma.Ethereum/Signer/EthECKey.cs
@@ -1,0 +1,242 @@
+﻿using System;
+using System.Linq;
+using System.Numerics;
+using Nethereum.Hex.HexConvertors.Extensions;
+using Nethereum.RLP;
+using Nethereum.Signer.Crypto;
+using Nethereum.Util;
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Agreement;
+using Org.BouncyCastle.Crypto.Generators;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Security;
+using Org.BouncyCastle.Utilities;
+
+namespace Nethereum.Signer
+{
+    public class EthECKey
+    {
+        private static readonly SecureRandom SecureRandom = new SecureRandom();
+        public static byte DEFAULT_PREFIX = 0x04;
+        private readonly ECKey _ecKey;
+
+        public EthECKey(string privateKey)
+        {
+            _ecKey = new ECKey(privateKey.HexToByteArray(), true);
+        }
+
+
+        public EthECKey(byte[] vch, bool isPrivate)
+        {
+            _ecKey = new ECKey(vch, isPrivate);
+        }
+
+        public EthECKey(byte[] vch, bool isPrivate, byte prefix)
+        {
+            _ecKey = new ECKey(ByteUtil.Merge(new[] {prefix}, vch), isPrivate);
+        }
+
+        internal EthECKey(ECKey ecKey)
+        {
+            _ecKey = ecKey;
+        }
+
+
+        public byte[] CalculateCommonSecret(EthECKey publicKey)
+        {
+            var agreement = new ECDHBasicAgreement();
+            agreement.Init(_ecKey.PrivateKey);
+            var z = agreement.CalculateAgreement(publicKey._ecKey.GetPublicKeyParameters());
+
+            return BigIntegers.AsUnsignedByteArray(agreement.GetFieldSize(), z);
+        }
+
+        //Note: Y coordinates can only be forced, so it is assumed 0 and 1 will be the recId (even if implementation allows for 2 and 3)
+        internal int CalculateRecId(ECDSASignature signature, byte[] hash)
+        {
+            //var recId = -1;
+            var thisKey = _ecKey.GetPubKey(false); // compressed
+            return CalculateRecId(signature, hash, thisKey);
+            //for (var i = 0; i < 4; i++)
+            //{
+            //    var rec = ECKey.RecoverFromSignature(i, signature, hash, false);
+            //    if (rec != null)
+            //    {
+            //        var k = rec.GetPubKey(false);
+            //        if (k != null && k.SequenceEqual(thisKey))
+            //        {
+            //            recId = i;
+            //            break;
+            //        }
+            //    }
+            //}
+            //if (recId == -1)
+            //    throw new Exception("Could not construct a recoverable key. This should never happen.");
+            //return recId;
+        }
+
+        internal static int CalculateRecId(ECDSASignature signature, byte[] hash, byte[] uncompressedPublicKey)
+        {
+            var recId = -1;
+
+            for (var i = 0; i < 4; i++)
+            {
+                var rec = ECKey.RecoverFromSignature(i, signature, hash, false);
+                if (rec != null)
+                {
+                    var k = rec.GetPubKey(false);
+                    if (k != null && k.SequenceEqual(uncompressedPublicKey))
+                    {
+                        recId = i;
+                        break;
+                    }
+                }
+            }
+            if (recId == -1)
+                throw new Exception("Could not construct a recoverable key. This should never happen.");
+            return recId;
+        }
+
+        public static EthECKey GenerateKey()
+        {
+            var gen = new ECKeyPairGenerator("EC");
+            var keyGenParam = new KeyGenerationParameters(SecureRandom, 256);
+            gen.Init(keyGenParam);
+            var keyPair = gen.GenerateKeyPair();
+            var privateBytes = ((ECPrivateKeyParameters) keyPair.Private).D.ToByteArray();
+            if (privateBytes.Length != 32)
+                return GenerateKey();
+            return new EthECKey(privateBytes, true);
+        }
+
+        public byte[] GetPrivateKeyAsBytes()
+        {
+            return _ecKey.PrivateKey.D.ToByteArrayUnsigned();
+        }
+
+        public string GetPrivateKey()
+        {
+            return GetPrivateKeyAsBytes().ToHex(true);
+        }
+
+        public byte[] GetPubKey()
+        {
+            return _ecKey.GetPubKey(false);
+        }
+
+        public byte[] GetPubKeyNoPrefix()
+        {
+            var pubKey = _ecKey.GetPubKey(false);
+            var arr = new byte[pubKey.Length - 1];
+            //remove the prefix
+            Array.Copy(pubKey, 1, arr, 0, arr.Length);
+            return arr;
+        }
+
+        public string GetPublicAddress()
+        {
+            var initaddr = new Sha3Keccack().CalculateHash(GetPubKeyNoPrefix());
+            var addr = new byte[initaddr.Length - 12];
+            Array.Copy(initaddr, 12, addr, 0, initaddr.Length - 12);
+            return new AddressUtil().ConvertToChecksumAddress(addr.ToHex());
+        }
+
+        public static string GetPublicAddress(string privateKey)
+        {
+            var key = new EthECKey(privateKey.HexToByteArray(), true);
+            return key.GetPublicAddress();
+        }
+
+        public static int GetRecIdFromV(byte[] v)
+        {
+            return GetRecIdFromV(v[0]);
+        }
+
+
+        public static int GetRecIdFromV(byte v)
+        {
+            var header = v;
+            // The header byte: 0x1B = first key with even y, 0x1C = first key with odd y,
+            //                  0x1D = second key with even y, 0x1E = second key with odd y
+            if (header < 27 || header > 34)
+                throw new Exception("Header byte out of range: " + header);
+            if (header >= 31)
+                header -= 4;
+            return header - 27;
+        }
+
+        public static int GetRecIdFromVChain(BigInteger vChain, BigInteger chainId)
+        {
+            return (int) (vChain - chainId * 2 - 35);
+        }
+
+        public static BigInteger GetChainFromVChain(BigInteger vChain)
+        {
+            var start = vChain - 35;
+            var even = start % 2 == 0;
+            if (even) return start / 2;
+            return (start - 1) / 2;
+        }
+
+        public static int GetRecIdFromVChain(byte[] vChain, BigInteger chainId)
+        {
+            return GetRecIdFromVChain(vChain.ToBigIntegerFromRLPDecoded(), chainId);
+        }
+
+        public static EthECKey RecoverFromSignature(EthECDSASignature signature, byte[] hash)
+        {
+            return new EthECKey(ECKey.RecoverFromSignature(GetRecIdFromV(signature.V), signature.ECDSASignature, hash,
+                false));
+        }
+
+        public static EthECKey RecoverFromSignature(EthECDSASignature signature, int recId, byte[] hash)
+        {
+            return new EthECKey(ECKey.RecoverFromSignature(recId, signature.ECDSASignature, hash, false));
+        }
+
+        public static EthECKey RecoverFromSignature(EthECDSASignature signature, byte[] hash, BigInteger chainId)
+        {
+            return new EthECKey(ECKey.RecoverFromSignature(GetRecIdFromVChain(signature.V, chainId),
+                signature.ECDSASignature, hash, false));
+        }
+
+        public EthECDSASignature SignAndCalculateV(byte[] hash, BigInteger chainId)
+        {
+            var signature = _ecKey.Sign(hash);
+            var recId = CalculateRecId(signature, hash);
+            var vChain = CalculateV(chainId, recId);
+            signature.V = vChain.ToBytesForRLPEncoding();
+            return new EthECDSASignature(signature);
+        }
+
+        internal static BigInteger CalculateV(BigInteger chainId, int recId)
+        {
+            return chainId * 2 + recId + 35;
+        }
+
+        public EthECDSASignature SignAndCalculateV(byte[] hash)
+        {
+            var signature = _ecKey.Sign(hash);
+            var recId = CalculateRecId(signature, hash);
+            signature.V = new[] {(byte) (recId + 27)};
+            return new EthECDSASignature(signature);
+        }
+
+        public EthECDSASignature Sign(byte[] hash)
+        {
+            var signature = _ecKey.Sign(hash);
+            return new EthECDSASignature(signature);
+        }
+
+        public bool Verify(byte[] hash, EthECDSASignature sig)
+        {
+            return _ecKey.Verify(hash, sig.ECDSASignature);
+        }
+
+        public bool VerifyAllowingOnlyLowS(byte[] hash, EthECDSASignature sig)
+        {
+            if (!sig.IsLowS) return false;
+            return _ecKey.Verify(hash, sig.ECDSASignature);
+        }
+    }
+}

--- a/Phantasma.Ethereum/Signer/EthECKeyExternalSigner.cs
+++ b/Phantasma.Ethereum/Signer/EthECKeyExternalSigner.cs
@@ -1,0 +1,86 @@
+﻿using System.Linq;
+using System.Numerics;
+using System.Threading.Tasks;
+using Nethereum.Hex.HexConvertors.Extensions;
+using Nethereum.RLP;
+using Nethereum.Signer.Crypto;
+
+namespace Nethereum.Signer
+{
+#if !DOTNET35
+    public abstract class EthExternalSignerBase : IEthExternalSigner
+    {
+        protected abstract Task<byte[]> GetPublicKeyAsync();
+        protected abstract Task<ECDSASignature> SignExternallyAsync(byte[] bytes);
+        public abstract Task SignAsync(TransactionChainId transaction);
+        public abstract Task SignAsync(Transaction transaction);
+        public abstract ExternalSignerTransactionFormat ExternalSignerTransactionFormat { get; protected set; }
+        public abstract bool CalculatesV { get; protected set; }
+
+        public virtual async Task<string> GetAddressAsync()
+        {
+            var publicKey = await GetPublicKeyAsync();
+            return new EthECKey(publicKey, false).GetPublicAddress();
+        }
+
+        public async Task<EthECDSASignature> SignAsync(byte[] rawBytes, BigInteger chainId)
+        {
+            var signature = await SignExternallyAsync(rawBytes);
+            if (CalculatesV) return new EthECDSASignature(signature);
+
+            var publicKey = await GetPublicKeyAsync();
+            var recId = EthECKey.CalculateRecId(signature, rawBytes, publicKey);
+            var vChain = EthECKey.CalculateV(chainId, recId);
+            signature.V = vChain.ToBytesForRLPEncoding();
+            return new EthECDSASignature(signature);
+        }
+
+        public async Task<EthECDSASignature> SignAsync(byte[] rawBytes)
+        {
+            var signature = await SignExternallyAsync(rawBytes);
+            if (CalculatesV) return new EthECDSASignature(signature);
+
+            var publicKey = await GetPublicKeyAsync();
+            var recId = EthECKey.CalculateRecId(signature, rawBytes, publicKey);
+            signature.V = new[] {(byte) (recId + 27)};
+            return new EthECDSASignature(signature);
+        }
+
+        protected async Task SignHashTransactionAsync(Transaction transaction)
+        {
+            if (ExternalSignerTransactionFormat == ExternalSignerTransactionFormat.Hash)
+            {
+                var signature = await SignAsync(transaction.RawHash);
+                transaction.SetSignature(signature);
+            }
+        }
+
+        protected async Task SignRLPTransactionAsync(Transaction transaction)
+        {
+            if (ExternalSignerTransactionFormat == ExternalSignerTransactionFormat.RLP)
+            {
+                var signature = await SignAsync(transaction.GetRLPEncodedRaw());
+                transaction.SetSignature(signature);
+            }
+        }
+
+        protected async Task SignHashTransactionAsync(TransactionChainId transaction)
+        {
+            if (ExternalSignerTransactionFormat == ExternalSignerTransactionFormat.Hash)
+            {
+                var signature = await SignAsync(transaction.RawHash, transaction.GetChainIdAsBigInteger());
+                transaction.SetSignature(signature);
+            }
+        }
+
+        protected async Task SignRLPTransactionAsync(TransactionChainId transaction)
+        {
+            if (ExternalSignerTransactionFormat == ExternalSignerTransactionFormat.RLP)
+            {
+                var signature = await SignAsync(transaction.RawHash, transaction.GetChainIdAsBigInteger());
+                transaction.SetSignature(signature);
+            }
+        }
+    }
+#endif
+}

--- a/Phantasma.Ethereum/Signer/EthereumMessageSigner.cs
+++ b/Phantasma.Ethereum/Signer/EthereumMessageSigner.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using System.Text;
+using Nethereum.Hex.HexConvertors.Extensions;
+
+namespace Nethereum.Signer
+{
+    public class EthereumMessageSigner : MessageSigner
+    {
+        public override string EcRecover(byte[] message, string signature)
+        {
+            return base.EcRecover(HashPrefixedMessage(message), signature);
+        }
+
+        public byte[] HashAndHashPrefixedMessage(byte[] message)
+        {
+            return HashPrefixedMessage(Hash(message));
+        }
+
+        public override string HashAndSign(byte[] plainMessage, EthECKey key)
+        {
+            return base.Sign(HashAndHashPrefixedMessage(plainMessage), key);
+        }
+
+        public byte[] HashPrefixedMessage(byte[] message)
+        {
+            var byteList = new List<byte>();
+            var bytePrefix = "0x19".HexToByteArray();
+            var textBytePrefix = Encoding.UTF8.GetBytes("Ethereum Signed Message:\n" + message.Length);
+
+            byteList.AddRange(bytePrefix);
+            byteList.AddRange(textBytePrefix);
+            byteList.AddRange(message);
+            return Hash(byteList.ToArray());
+        }
+
+        public override string Sign(byte[] message, EthECKey key)
+        {
+            return base.Sign(HashPrefixedMessage(message), key);
+        }
+
+        public string EncodeUTF8AndSign(string message, EthECKey key)
+        {
+            return base.Sign(HashPrefixedMessage(Encoding.UTF8.GetBytes(message)), key);
+        }
+
+        public string EncodeUTF8AndEcRecover(string message, string signature)
+        {
+            return EcRecover(Encoding.UTF8.GetBytes(message), signature);
+        }
+    }
+}

--- a/Phantasma.Ethereum/Signer/IEthExternalSigner.cs
+++ b/Phantasma.Ethereum/Signer/IEthExternalSigner.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+using Nethereum.Signer.Crypto;
+
+namespace Nethereum.Signer
+{
+#if !DOTNET35
+
+    public enum ExternalSignerTransactionFormat
+    {
+        RLP,
+        Hash,
+        Transaction
+    }
+    
+#endif
+}

--- a/Phantasma.Ethereum/Signer/IEthExternalSignerBase.cs
+++ b/Phantasma.Ethereum/Signer/IEthExternalSignerBase.cs
@@ -1,0 +1,18 @@
+﻿using System.Numerics;
+using System.Threading.Tasks;
+
+namespace Nethereum.Signer
+{
+#if !DOTNET35
+    public interface IEthExternalSigner
+    {
+        bool CalculatesV { get; }
+        ExternalSignerTransactionFormat ExternalSignerTransactionFormat { get; }
+        Task<string> GetAddressAsync();
+        Task<EthECDSASignature> SignAsync(byte[] rawBytes);
+        Task<EthECDSASignature> SignAsync(byte[] rawBytes, BigInteger chainId);
+        Task SignAsync(Transaction transaction);
+        Task SignAsync(TransactionChainId transaction);
+    }
+#endif
+}

--- a/Phantasma.Ethereum/Signer/MessageSigner.cs
+++ b/Phantasma.Ethereum/Signer/MessageSigner.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Text;
+using Nethereum.Hex.HexConvertors.Extensions;
+using Nethereum.Util;
+
+namespace Nethereum.Signer
+{
+    public class MessageSigner
+    {
+        public virtual string EcRecover(byte[] hashMessage, string signature)
+        {
+            var ecdaSignature = ExtractEcdsaSignature(signature);
+            return EthECKey.RecoverFromSignature(ecdaSignature, hashMessage).GetPublicAddress();
+        }
+
+        public byte[] Hash(byte[] plainMessage)
+        {
+            var hash = new Sha3Keccack().CalculateHash(plainMessage);
+            return hash;
+        }
+
+        public string HashAndEcRecover(string plainMessage, string signature)
+        {
+            return EcRecover(Hash(Encoding.UTF8.GetBytes(plainMessage)), signature);
+        }
+
+        public string HashAndSign(string plainMessage, string privateKey)
+        {
+            return HashAndSign(Encoding.UTF8.GetBytes(plainMessage), new EthECKey(privateKey.HexToByteArray(), true));
+        }
+
+        public string HashAndSign(byte[] plainMessage, string privateKey)
+        {
+            return HashAndSign(plainMessage, new EthECKey(privateKey.HexToByteArray(), true));
+        }
+
+        public virtual string HashAndSign(byte[] plainMessage, EthECKey key)
+        {
+            var hash = Hash(plainMessage);
+            var signature = key.SignAndCalculateV(hash);
+            return CreateStringSignature(signature);
+        }
+
+        public string Sign(byte[] message, string privateKey)
+        {
+            return Sign(message, new EthECKey(privateKey.HexToByteArray(), true));
+        }
+
+        public virtual string Sign(byte[] message, EthECKey key)
+        {
+            var signature = key.SignAndCalculateV(message);
+            return CreateStringSignature(signature);
+        }
+
+        public virtual EthECDSASignature SignAndCalculateV(byte[] message, string privateKey)
+        {
+            return new EthECKey(privateKey.HexToByteArray(), true).SignAndCalculateV(message);
+        }
+
+        private static string CreateStringSignature(EthECDSASignature signature)
+        {
+            return EthECDSASignature.CreateStringSignature(signature);
+        }
+
+        public static EthECDSASignature ExtractEcdsaSignature(string signature)
+        {
+            return EthECDSASignatureFactory.ExtractECDSASignature(signature);
+        }
+    }
+}

--- a/Phantasma.Ethereum/Signer/RLPDecoder.cs
+++ b/Phantasma.Ethereum/Signer/RLPDecoder.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using Nethereum.RLP;
+
+namespace Nethereum.Signer
+{
+    public class RLPDecoder
+    {
+        public static SignedData DecodeSigned(byte[] rawdata, int numberOfEncodingElements)
+        {
+            var decodedList = RLP.RLP.Decode(rawdata);
+            var decodedData = new List<byte[]>();
+            var decodedElements = (RLPCollection)decodedList;
+            EthECDSASignature signature = null;
+            for (var i = 0; i < numberOfEncodingElements; i++)
+                decodedData.Add(decodedElements[i].RLPData);
+            // only parse signature in case is signed
+            if (decodedElements[numberOfEncodingElements].RLPData != null)
+            {
+                //Decode Signature
+                var v = decodedElements[numberOfEncodingElements].RLPData;
+                var r = decodedElements[numberOfEncodingElements + 1].RLPData;
+                var s = decodedElements[numberOfEncodingElements + 2].RLPData;
+                signature = EthECDSASignatureFactory.FromComponents(r, s, v);
+            }
+            return new SignedData(decodedData.ToArray(), signature);
+        }
+    }
+}

--- a/Phantasma.Ethereum/Signer/RLPEncoder.cs
+++ b/Phantasma.Ethereum/Signer/RLPEncoder.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Linq;
+using Nethereum.Model;
+
+namespace Nethereum.Signer
+{
+    public class RLPEncoder
+    {
+        public static byte[] EncodeSigned(SignedData signedData, int numberOfElements)
+        {
+            var encodedData = new List<byte[]>();
+            for (var i = 0; i < numberOfElements; i++)
+                encodedData.Add(RLP.RLP.EncodeElement(signedData.Data[i]));
+
+            byte[] v, r, s;
+
+            if (signedData.IsSigned())
+            {
+                v = RLP.RLP.EncodeElement(signedData.V);
+                r = RLP.RLP.EncodeElement(signedData.R);
+                s = RLP.RLP.EncodeElement(signedData.S);
+            }
+            else
+            {
+                v = RLP.RLP.EncodeElement(DefaultValues.EMPTY_BYTE_ARRAY);
+                r = RLP.RLP.EncodeElement(DefaultValues.EMPTY_BYTE_ARRAY);
+                s = RLP.RLP.EncodeElement(DefaultValues.EMPTY_BYTE_ARRAY);
+            }
+
+            encodedData.Add(v);
+            encodedData.Add(r);
+            encodedData.Add(s);
+
+            return RLP.RLP.EncodeList(encodedData.ToArray());
+        }
+
+    }
+}

--- a/Phantasma.Ethereum/Signer/RLPSigner.cs
+++ b/Phantasma.Ethereum/Signer/RLPSigner.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Threading.Tasks;
+using Nethereum.Util;
+
+namespace Nethereum.Signer
+{
+    public class RLPSigner
+    {
+        private readonly int numberOfEncodingElements;
+        private byte[] rlpSignedEncoded;
+        private byte[] rlpRawWitNoSignature;
+
+        public RLPSigner(byte[] rawData, int numberOfEncodingElements)
+        {
+            rlpSignedEncoded = rawData;
+            this.numberOfEncodingElements = numberOfEncodingElements;
+            Decode();
+        }
+
+        public RLPSigner(byte[][] data) : this(data, data.Length)
+        {
+        }
+
+        public RLPSigner(byte[][] data, int numberOfEncodingElements)
+        {
+            this.numberOfEncodingElements = numberOfEncodingElements;
+            this.Data = data;
+        }
+
+        public RLPSigner(byte[][] data, byte[] r, byte[] s, byte v) : this(data, r, s, v, data.Length)
+        {
+        }
+
+        public RLPSigner(byte[][] data, byte[] r, byte[] s, byte v, int numberOfEncodingElements)
+        {
+            this.numberOfEncodingElements = numberOfEncodingElements;
+            this.Data = data;
+            Signature = EthECDSASignatureFactory.FromComponents(r, s, v);
+        }
+
+        public RLPSigner(byte[][] data, byte[] r, byte[] s, byte[] v) : this(data, r, s, v, data.Length)
+        {
+        }
+
+        public RLPSigner(byte[][] data, byte[] r, byte[] s, byte[] v, int numberOfEncodingElements)
+        {
+            this.numberOfEncodingElements = numberOfEncodingElements;
+            this.Data = data;
+            Signature = EthECDSASignatureFactory.FromComponents(r, s, v);
+        }
+
+        public byte[] RawHash
+        {
+            get
+            {
+                var plainMsg = GetRLPEncodedRaw();
+                return new Sha3Keccack().CalculateHash(plainMsg);
+            }
+        }
+
+        public byte[] Hash
+        {
+            get
+            {
+                var plainMsg = GetRLPEncoded();
+                return new Sha3Keccack().CalculateHash(plainMsg);
+            }
+        }
+
+        public byte[][] Data { get; private set; }
+
+        public EthECDSASignature Signature { get; private set; }
+
+        public byte[] GetRLPEncoded()
+        {
+            if (rlpSignedEncoded != null) return rlpSignedEncoded;
+            rlpSignedEncoded = RLPEncoder.EncodeSigned(new SignedData(Data, Signature), numberOfEncodingElements);
+            return rlpSignedEncoded;
+        }
+
+        public byte[] GetRLPEncodedRaw()
+        {
+            rlpRawWitNoSignature = RLP.RLP.EncodeElementsAndList(Data);
+            return rlpRawWitNoSignature;
+        }
+
+        public void AppendData(params byte[][] extraData)
+        {
+            var fullData = new List<byte[]>();
+            fullData.AddRange(Data);
+            fullData.AddRange(extraData);
+            Data = fullData.ToArray();
+        }
+
+        public void Sign(EthECKey key)
+        {
+            Signature = key.SignAndCalculateV(RawHash);
+            rlpSignedEncoded = null;
+        }
+
+        public void Sign(EthECKey key, BigInteger chainId)
+        {
+            Signature = key.SignAndCalculateV(RawHash, chainId);
+            rlpSignedEncoded = null;
+        }
+
+        public void SetSignature(EthECDSASignature signature)
+        {
+            Signature = signature;
+            rlpSignedEncoded = null;
+        }
+
+        public bool IsVSignatureForChain()
+        {
+            if(Signature == null) throw new Exception("Signature not initiated or calculated");
+            return Signature.IsVSignedForChain();
+        }
+
+        private void Decode()
+        {
+            var signedData = RLPDecoder.DecodeSigned(rlpSignedEncoded, numberOfEncodingElements);
+            Data = signedData.Data;
+            Signature = signedData.GetSignature();
+        }
+    }
+}

--- a/Phantasma.Ethereum/Signer/SignedData.cs
+++ b/Phantasma.Ethereum/Signer/SignedData.cs
@@ -1,0 +1,37 @@
+namespace Nethereum.Signer
+{
+    public class SignedData
+    {
+        public byte[][] Data { get; set; }
+        public byte[] V { get; set; }
+        public byte[] R { get; set; }
+        public byte[] S { get; set; }
+
+        public EthECDSASignature GetSignature()
+        {
+            if (!IsSigned()) return null;
+            return EthECDSASignatureFactory.FromComponents(R, S, V);
+        }
+
+        public bool IsSigned()
+        {
+            return (V != null);
+        }
+
+        public SignedData()
+        {
+
+        }
+
+        public SignedData(byte[][] data, EthECDSASignature signature)
+        {
+            Data = data;
+            if (signature != null)
+            {
+                R = signature.R;
+                S = signature.S;
+                V = signature.V;
+            }
+        }
+    }
+}

--- a/Phantasma.Ethereum/Signer/SignedTransactionBase.cs
+++ b/Phantasma.Ethereum/Signer/SignedTransactionBase.cs
@@ -1,0 +1,75 @@
+﻿using System.Numerics;
+using System.Threading.Tasks;
+using Nethereum.Model;
+using Nethereum.Hex.HexConvertors.Extensions;
+
+namespace Nethereum.Signer
+{
+    public abstract class SignedTransactionBase
+    {
+        public static RLPSigner CreateDefaultRLPSigner(byte[] rawData)
+        {
+           return new RLPSigner(rawData, NUMBER_ENCODING_ELEMENTS);  
+        }
+
+        //Number of encoding elements (output for transaction)
+        public const int NUMBER_ENCODING_ELEMENTS = 6;
+        public static readonly BigInteger DEFAULT_GAS_PRICE = BigInteger.Parse("20000000000");
+        public static readonly BigInteger DEFAULT_GAS_LIMIT = BigInteger.Parse("21000");
+
+
+        protected RLPSigner SimpleRlpSigner { get; set; }
+
+        public byte[] RawHash => SimpleRlpSigner.RawHash;
+
+        /// <summary>
+        ///     The counter used to make sure each transaction can only be processed once, you may need to regenerate the
+        ///     transaction if is too low or too high, simples way is to get the number of transacations
+        /// </summary>
+        public byte[] Nonce => SimpleRlpSigner.Data[0] ?? DefaultValues.ZERO_BYTE_ARRAY;
+
+        public byte[] Value => SimpleRlpSigner.Data[4] ?? DefaultValues.ZERO_BYTE_ARRAY;
+
+        public byte[] ReceiveAddress => SimpleRlpSigner.Data[3];
+
+        public byte[] GasPrice => SimpleRlpSigner.Data[1] ?? DefaultValues.ZERO_BYTE_ARRAY;
+
+        public byte[] GasLimit => SimpleRlpSigner.Data[2];
+
+        public byte[] Data => SimpleRlpSigner.Data[5];
+
+        public EthECDSASignature Signature => SimpleRlpSigner.Signature;
+
+        public abstract EthECKey Key { get;  }
+            
+
+        public byte[] GetRLPEncoded()
+        {
+            return SimpleRlpSigner.GetRLPEncoded();
+        }
+
+        public byte[] GetRLPEncodedRaw()
+        {
+            return SimpleRlpSigner.GetRLPEncodedRaw();
+        }
+
+        public virtual void Sign(EthECKey key)
+        {
+            SimpleRlpSigner.Sign(key);
+        }
+
+        public void SetSignature(EthECDSASignature signature)
+        {
+            SimpleRlpSigner.SetSignature(signature);
+        }
+
+        protected static string ToHex(byte[] x)
+        {
+            if (x == null) return "0x";
+            return x.ToHex();
+        }
+#if !DOTNET35
+        public abstract Task SignExternallyAsync(IEthExternalSigner externalSigner);
+#endif
+    }
+}

--- a/Phantasma.Ethereum/Signer/Transaction.cs
+++ b/Phantasma.Ethereum/Signer/Transaction.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Numerics;
+using System.Threading.Tasks;
+using Nethereum.Hex.HexConvertors.Extensions;
+using Nethereum.Model;
+using Nethereum.RLP;
+
+namespace Nethereum.Signer
+{
+    public class Transaction : SignedTransactionBase
+    {
+        public Transaction(byte[] rawData)
+        {
+            SimpleRlpSigner = new RLPSigner(rawData, NUMBER_ENCODING_ELEMENTS);
+            ValidateValidV(SimpleRlpSigner);
+        }
+
+        public Transaction(RLPSigner rlpSigner)
+        {
+            ValidateValidV(rlpSigner);
+            SimpleRlpSigner = rlpSigner;
+        }
+
+        private static void ValidateValidV(RLPSigner rlpSigner)
+        {
+            if (rlpSigner.IsVSignatureForChain())
+                throw new Exception("TransactionChainId should be used instead of Transaction");
+        }
+
+        public Transaction(byte[] nonce, byte[] gasPrice, byte[] gasLimit, byte[] receiveAddress, byte[] value,
+            byte[] data)
+        {
+            SimpleRlpSigner = new RLPSigner(GetElementsInOrder(nonce, gasPrice, gasLimit, receiveAddress, value, data));
+        }
+
+        public Transaction(byte[] nonce, byte[] gasPrice, byte[] gasLimit, byte[] receiveAddress, byte[] value,
+            byte[] data, byte[] r, byte[] s, byte v)
+        {
+            SimpleRlpSigner = new RLPSigner(GetElementsInOrder(nonce, gasPrice, gasLimit, receiveAddress, value, data),
+                r, s, v);
+        }
+
+        public Transaction(string to, BigInteger amount, BigInteger nonce)
+            : this(to, amount, nonce, DEFAULT_GAS_PRICE, DEFAULT_GAS_LIMIT)
+        {
+        }
+
+        public Transaction(string to, BigInteger amount, BigInteger nonce, string data)
+            : this(to, amount, nonce, DEFAULT_GAS_PRICE, DEFAULT_GAS_LIMIT, data)
+        {
+        }
+
+        public Transaction(string to, BigInteger amount, BigInteger nonce, BigInteger gasPrice, BigInteger gasLimit)
+            : this(to, amount, nonce, gasPrice, gasLimit, "")
+        {
+        }
+
+        public Transaction(string to, BigInteger amount, BigInteger nonce, BigInteger gasPrice,
+            BigInteger gasLimit, string data) : this(nonce.ToBytesForRLPEncoding(), gasPrice.ToBytesForRLPEncoding(),
+            gasLimit.ToBytesForRLPEncoding(), to.HexToByteArray(), amount.ToBytesForRLPEncoding(), data.HexToByteArray()
+        )
+        {
+        }
+
+        public string ToJsonHex()
+        {
+            var s = "['{0}','{1}','{2}','{3}','{4}','{5}','{6}','{7}','{8}']";
+            return string.Format(s, Nonce.ToHex(),
+                GasPrice.ToHex(), GasLimit.ToHex(), ReceiveAddress.ToHex(), Value.ToHex(), ToHex(Data),
+                Signature.V.ToHex(),
+                Signature.R.ToHex(),
+                Signature.S.ToHex());
+        }
+
+        private byte[][] GetElementsInOrder(byte[] nonce, byte[] gasPrice, byte[] gasLimit, byte[] receiveAddress,
+            byte[] value,
+            byte[] data)
+        {
+            if (receiveAddress == null)
+                receiveAddress = DefaultValues.EMPTY_BYTE_ARRAY;
+            //order  nonce, gasPrice, gasLimit, receiveAddress, value, data
+            return new[] {nonce, gasPrice, gasLimit, receiveAddress, value, data};
+        }
+
+        public override EthECKey Key => EthECKey.RecoverFromSignature(SimpleRlpSigner.Signature, SimpleRlpSigner.RawHash);
+
+#if !DOTNET35
+        public override async Task SignExternallyAsync(IEthExternalSigner externalSigner)
+        {
+           await externalSigner.SignAsync(this).ConfigureAwait(false);
+        }
+#endif
+    }
+}

--- a/Phantasma.Ethereum/Signer/TransactionChainId.cs
+++ b/Phantasma.Ethereum/Signer/TransactionChainId.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using System.Numerics;
+using System.Threading.Tasks;
+using Nethereum.Hex.HexConvertors.Extensions;
+using Nethereum.Model;
+using Nethereum.RLP;
+
+namespace Nethereum.Signer
+{
+    public class TransactionChainId : SignedTransactionBase
+    {  
+        //The R and S Hashing values
+        private static readonly byte[] RHASH_DEFAULT = 0.ToBytesForRLPEncoding();
+        private static readonly byte[] SHASH_DEFAULT = 0.ToBytesForRLPEncoding();
+
+        public TransactionChainId(byte[] rawData, BigInteger chainId)
+        {
+            //Instantiate and decode
+            SimpleRlpSigner = new RLPSigner(rawData, NUMBER_ENCODING_ELEMENTS);
+            ValidateValidV(SimpleRlpSigner);
+            AppendDataForHashRecovery(chainId);
+        }
+
+        public TransactionChainId(RLPSigner rlpSigner)
+        {
+            SimpleRlpSigner = rlpSigner;
+            ValidateValidV(SimpleRlpSigner);
+            GetChainIdFromVAndAppendDataForHashRecovery();
+        }
+
+        private static void ValidateValidV(RLPSigner rlpSigner)
+        {
+            if (!rlpSigner.IsVSignatureForChain())
+                throw new Exception("Transaction should be used instead of TransactionChainId, invalid V");
+        }
+        private void GetChainIdFromVAndAppendDataForHashRecovery()
+        {
+            var chainId = GetChainFromVChain();
+            AppendDataForHashRecovery(chainId);
+        }
+
+        private void AppendDataForHashRecovery(BigInteger chainId)
+        {
+            //append the chainId, r and s so it can be recovered using the raw hash
+            //the encoding has only the default 6 values
+            SimpleRlpSigner.AppendData(chainId.ToBytesForRLPEncoding(), RHASH_DEFAULT,
+                SHASH_DEFAULT);
+        }
+
+        public TransactionChainId(byte[] rawData)
+        {
+            //Instantiate and decode
+            SimpleRlpSigner = new RLPSigner(rawData, NUMBER_ENCODING_ELEMENTS);
+            ValidateValidV(SimpleRlpSigner);
+            GetChainIdFromVAndAppendDataForHashRecovery();
+        }
+
+        private BigInteger GetChainFromVChain()
+        {
+            return EthECKey.GetChainFromVChain(Signature.V.ToBigIntegerFromRLPDecoded());
+        }
+
+        public TransactionChainId(byte[] nonce, byte[] gasPrice, byte[] gasLimit, byte[] receiveAddress, byte[] value,
+            byte[] data, byte[] chainId)
+        {
+            SimpleRlpSigner =
+                new RLPSigner(GetElementsInOrder(nonce, gasPrice, gasLimit, receiveAddress, value, data, chainId),
+                    NUMBER_ENCODING_ELEMENTS);
+        }
+
+        public TransactionChainId(byte[] nonce, byte[] gasPrice, byte[] gasLimit, byte[] receiveAddress, byte[] value,
+            byte[] data, byte[] chainId, byte[] r, byte[] s, byte[] v)
+        {
+            SimpleRlpSigner = new RLPSigner(
+                GetElementsInOrder(nonce, gasPrice, gasLimit, receiveAddress, value, data, chainId),
+                r, s, v, NUMBER_ENCODING_ELEMENTS);
+        }
+
+        public TransactionChainId(string to, BigInteger amount, BigInteger nonce, BigInteger chainId)
+            : this(to, amount, nonce, DEFAULT_GAS_PRICE, DEFAULT_GAS_LIMIT, chainId)
+        {
+        }
+
+        public TransactionChainId(string to, BigInteger amount, BigInteger nonce, string data, BigInteger chainId)
+            : this(to, amount, nonce, DEFAULT_GAS_PRICE, DEFAULT_GAS_LIMIT, data, chainId)
+        {
+        }
+
+        public TransactionChainId(string to, BigInteger amount, BigInteger nonce, BigInteger gasPrice,
+            BigInteger gasLimit, BigInteger chainId)
+            : this(to, amount, nonce, gasPrice, gasLimit, "", chainId)
+        {
+        }
+
+        public TransactionChainId(string to, BigInteger amount, BigInteger nonce, BigInteger gasPrice,
+            BigInteger gasLimit, string data, BigInteger chainId) : this(nonce.ToBytesForRLPEncoding(),
+            gasPrice.ToBytesForRLPEncoding(),
+            gasLimit.ToBytesForRLPEncoding(), to.HexToByteArray(), amount.ToBytesForRLPEncoding(),
+            data.HexToByteArray(), chainId.ToBytesForRLPEncoding()
+        )
+        {
+        }
+
+        public BigInteger GetChainIdAsBigInteger()
+        {
+            return ChainId.ToBigIntegerFromRLPDecoded();
+        }
+
+        public byte[] ChainId => SimpleRlpSigner.Data[6];
+
+        public byte[] RHash => SimpleRlpSigner.Data[7];
+
+        public byte[] SHash => SimpleRlpSigner.Data[8];
+
+        /// <summary>
+        /// Recovered Key from Signature
+        /// </summary>
+        public override EthECKey Key => EthECKey.RecoverFromSignature(SimpleRlpSigner.Signature,
+            SimpleRlpSigner.RawHash,
+            ChainId.ToBigIntegerFromRLPDecoded());
+
+        public string ToJsonHex()
+        {
+            var data =
+                $"['{Nonce.ToHex()}','{GasPrice.ToHex()}','{GasLimit.ToHex()}','{ReceiveAddress.ToHex()}','{Value.ToHex()}','{ToHex(Data)}','{ChainId.ToHex()}','{RHash.ToHex()}','{SHash.ToHex()}'";
+
+            if (Signature != null)
+                data = data + $", '{Signature.V.ToHex()}', '{Signature.R.ToHex()}', '{Signature.S.ToHex()}'";
+            return data + "]";
+        }
+
+        public override void Sign(EthECKey key)
+        {
+            SimpleRlpSigner.Sign(key, GetChainIdAsBigInteger());
+        }
+
+        private byte[][] GetElementsInOrder(byte[] nonce, byte[] gasPrice, byte[] gasLimit, byte[] receiveAddress,
+            byte[] value,
+            byte[] data, byte[] chainId)
+        {
+            if (receiveAddress == null)
+                receiveAddress = DefaultValues.EMPTY_BYTE_ARRAY;
+            //order  nonce, gasPrice, gasLimit, receiveAddress, value, data, chainId, r = 0, s =0
+            return new[]
+            {
+                nonce, gasPrice, gasLimit, receiveAddress, value, data, chainId, RHASH_DEFAULT,
+                SHASH_DEFAULT
+            };
+        }
+
+#if !DOTNET35
+        public override async Task SignExternallyAsync(IEthExternalSigner externalSigner)
+        {
+           await externalSigner.SignAsync(this).ConfigureAwait(false);
+        }
+#endif
+
+    }
+
+}

--- a/Phantasma.Ethereum/Signer/TransactionFactory.cs
+++ b/Phantasma.Ethereum/Signer/TransactionFactory.cs
@@ -1,0 +1,44 @@
+﻿using Nethereum.Hex.HexConvertors.Extensions;
+using Nethereum.RLP;
+using System.Numerics;
+
+namespace Nethereum.Signer
+{
+    public class TransactionFactory
+    {
+        public static SignedTransactionBase CreateTransaction(string rlpHex)
+        {
+            return CreateTransaction(rlpHex.HexToByteArray());
+        }
+
+        public static SignedTransactionBase CreateTransaction(byte[] rlp)
+        {
+            var rlpSigner = SignedTransactionBase.CreateDefaultRLPSigner(rlp);
+            return rlpSigner.IsVSignatureForChain()
+                ? (SignedTransactionBase) new TransactionChainId(rlpSigner)
+                : new Transaction(rlpSigner);
+        }
+
+        public static SignedTransactionBase CreateTransaction(string to, BigInteger gas, BigInteger gasPrice, BigInteger amount, string data, BigInteger nonce, string r, string s, string v)
+        {
+            var rBytes = r.HexToByteArray();
+            var sBytes = s.HexToByteArray();
+            var vBytes = v.HexToByteArray();
+            
+            var signature = EthECDSASignatureFactory.FromComponents(rBytes, sBytes, vBytes);
+            if (signature.IsVSignedForChain())
+            {
+                var vBigInteger = vBytes.ToBigIntegerFromRLPDecoded();
+                var chainId = EthECKey.GetChainFromVChain(vBigInteger);
+                return new TransactionChainId(nonce.ToBytesForRLPEncoding(), gasPrice.ToBytesForRLPEncoding(), gas.ToBytesForRLPEncoding(),
+                    to.HexToByteArray(), amount.ToBytesForRLPEncoding(), data.HexToByteArray(), chainId.ToBytesForRLPEncoding(), rBytes, sBytes, vBytes);
+            }
+            else
+            {
+                return new Transaction(nonce.ToBytesForRLPEncoding(), gasPrice.ToBytesForRLPEncoding(), gas.ToBytesForRLPEncoding(),
+                    to.HexToByteArray(), amount.ToBytesForRLPEncoding(), data.HexToByteArray(), rBytes, sBytes, vBytes[0]);
+            }
+        }
+        
+    }
+}

--- a/Phantasma.Ethereum/Signer/TransactionSigner.cs
+++ b/Phantasma.Ethereum/Signer/TransactionSigner.cs
@@ -1,0 +1,332 @@
+﻿using System.Numerics;
+using System.Threading.Tasks;
+using Nethereum.Hex.HexConvertors.Extensions;
+
+namespace Nethereum.Signer
+{
+    public class TransactionSigner
+    {
+        public byte[] GetPublicKey(string rlp)
+        {
+            var transaction = TransactionFactory.CreateTransaction(rlp);
+            return transaction.Key.GetPubKey();
+        }
+
+        public string GetSenderAddress(string rlp)
+        {
+            var transaction = TransactionFactory.CreateTransaction(rlp);
+            return transaction.Key.GetPublicAddress();
+        }
+
+        public bool VerifyTransaction(string rlp)
+        {
+            var transaction = TransactionFactory.CreateTransaction(rlp);
+            return transaction.Key.VerifyAllowingOnlyLowS(transaction.RawHash, transaction.Signature);
+        }
+
+        public byte[] GetPublicKey(string rlp, Chain chain)
+        {
+            return GetPublicKey(rlp, (int)chain);
+        }
+
+        public byte[] GetPublicKey(string rlp, BigInteger chainId)
+        {
+            var transaction = new TransactionChainId(rlp.HexToByteArray(), chainId);
+            return transaction.Key.GetPubKey();
+        }
+
+        public string GetSenderAddress(string rlp, Chain chain)
+        {
+            return GetSenderAddress(rlp, (int)chain);
+        }
+
+        public string GetSenderAddress(string rlp, BigInteger chainId)
+        {
+            var transaction = new TransactionChainId(rlp.HexToByteArray(), chainId);
+            return transaction.Key.GetPublicAddress();
+        }
+
+        public bool VerifyTransaction(string rlp, Chain chain)
+        {
+            return VerifyTransaction(rlp, (int)chain);
+        }
+
+        public bool VerifyTransaction(string rlp, BigInteger chainId)
+        {
+            var transaction = new TransactionChainId(rlp.HexToByteArray(), chainId);
+            return transaction.Key.VerifyAllowingOnlyLowS(transaction.RawHash, transaction.Signature);
+        }
+
+        public string SignTransaction(string privateKey, string to, BigInteger amount, BigInteger nonce)
+        {
+            return SignTransaction(privateKey.HexToByteArray(), to, amount, nonce);
+        }
+
+        public string SignTransaction(string privateKey, string to, BigInteger amount, BigInteger nonce, string data)
+        {
+            return SignTransaction(privateKey.HexToByteArray(), to, amount, nonce, data);
+        }
+
+        public string SignTransaction(string privateKey, string to, BigInteger amount, BigInteger nonce,
+            BigInteger gasPrice,
+            BigInteger gasLimit)
+        {
+            return SignTransaction(privateKey.HexToByteArray(), to, amount, nonce, gasPrice, gasLimit);
+        }
+
+        public string SignTransaction(string privateKey, string to, BigInteger amount, BigInteger nonce,
+            BigInteger gasPrice,
+            BigInteger gasLimit, string data)
+        {
+            return SignTransaction(privateKey.HexToByteArray(), to, amount, nonce, gasPrice, gasLimit, data);
+        }
+
+        public string SignTransaction(byte[] privateKey, string to, BigInteger amount, BigInteger nonce)
+        {
+            var transaction = new Transaction(to, amount, nonce);
+            return SignTransaction(privateKey, transaction);
+        }
+
+        public string SignTransaction(byte[] privateKey, string to, BigInteger amount, BigInteger nonce, string data)
+        {
+            var transaction = new Transaction(to, amount, nonce, data);
+            return SignTransaction(privateKey, transaction);
+        }
+
+        public string SignTransaction(byte[] privateKey, string to, BigInteger amount, BigInteger nonce,
+            BigInteger gasPrice,
+            BigInteger gasLimit)
+        {
+            var transaction = new Transaction(to, amount, nonce, gasPrice, gasLimit);
+            return SignTransaction(privateKey, transaction);
+        }
+
+        public string SignTransaction(byte[] privateKey, string to, BigInteger amount, BigInteger nonce,
+            BigInteger gasPrice,
+            BigInteger gasLimit, string data)
+        {
+            var transaction = new Transaction(to, amount, nonce, gasPrice, gasLimit, data);
+            return SignTransaction(privateKey, transaction);
+        }
+
+        public string SignTransaction(string privateKey, Chain chain, string to, BigInteger amount,
+            BigInteger nonce)
+        {
+            return SignTransaction(privateKey, new BigInteger((int)chain), to, amount, nonce);
+        }
+
+        public string SignTransaction(string privateKey, BigInteger chainId, string to, BigInteger amount,
+            BigInteger nonce)
+        {
+            return SignTransaction(privateKey.HexToByteArray(), chainId, to, amount, nonce);
+        }
+
+        public string SignTransaction(string privateKey, Chain chain, string to, BigInteger amount,
+            BigInteger nonce, string data)
+        {
+            return SignTransaction(privateKey, new BigInteger((int)chain), to, amount, nonce, data);
+        }
+
+        public string SignTransaction(string privateKey, BigInteger chainId, string to, BigInteger amount,
+            BigInteger nonce, string data)
+        {
+            return SignTransaction(privateKey.HexToByteArray(), chainId, to, amount, nonce, data);
+        }
+
+        public string SignTransaction(string privateKey, Chain chain, string to, BigInteger amount,
+            BigInteger nonce, BigInteger gasPrice,
+            BigInteger gasLimit)
+        {
+            return SignTransaction(privateKey, new BigInteger((int)chain), to, amount, nonce, gasPrice, gasLimit);
+        }
+
+        public string SignTransaction(string privateKey, BigInteger chainId, string to, BigInteger amount,
+            BigInteger nonce, BigInteger gasPrice,
+            BigInteger gasLimit)
+        {
+            return SignTransaction(privateKey.HexToByteArray(), chainId, to, amount, nonce, gasPrice, gasLimit);
+        }
+
+        public string SignTransaction(string privateKey, Chain chain, string to, BigInteger amount,
+            BigInteger nonce, BigInteger gasPrice,
+            BigInteger gasLimit, string data)
+        {
+            return SignTransaction(privateKey, new BigInteger((int)chain), to, amount, nonce, gasPrice, gasLimit, data);
+        }
+
+        public string SignTransaction(string privateKey, BigInteger chainId, string to, BigInteger amount,
+            BigInteger nonce, BigInteger gasPrice,
+            BigInteger gasLimit, string data)
+        {
+            return SignTransaction(privateKey.HexToByteArray(), chainId, to, amount, nonce, gasPrice, gasLimit, data);
+        }
+
+        public string SignTransaction(byte[] privateKey, Chain chain, string to, BigInteger amount,
+            BigInteger nonce)
+        {
+            return SignTransaction(privateKey, (int)chain, to, amount, nonce);
+        }
+
+        public string SignTransaction(byte[] privateKey, BigInteger chainId, string to, BigInteger amount,
+            BigInteger nonce)
+        {
+            var transaction = new TransactionChainId(to, amount, nonce, chainId);
+            return SignTransaction(privateKey, transaction);
+        }
+
+        public string SignTransaction(byte[] privateKey, Chain chain, string to, BigInteger amount,
+            BigInteger nonce, string data)
+        {
+            return SignTransaction(privateKey, (int)chain, to, amount, nonce, data);
+        }
+
+        public string SignTransaction(byte[] privateKey, BigInteger chainId, string to, BigInteger amount,
+            BigInteger nonce, string data)
+        {
+            var transaction = new TransactionChainId(to, amount, nonce, data, chainId);
+            return SignTransaction(privateKey, transaction);
+        }
+
+        public string SignTransaction(byte[] privateKey, Chain chain, string to, BigInteger amount,
+            BigInteger nonce, BigInteger gasPrice,
+            BigInteger gasLimit)
+        {
+            return SignTransaction(privateKey, (int)chain, to, amount, nonce, gasPrice, gasLimit);
+        }
+
+        public string SignTransaction(byte[] privateKey, BigInteger chainId, string to, BigInteger amount,
+            BigInteger nonce, BigInteger gasPrice,
+            BigInteger gasLimit)
+        {
+            var transaction = new TransactionChainId(to, amount, nonce, gasPrice, gasLimit, chainId);
+            return SignTransaction(privateKey, transaction);
+        }
+
+        public string SignTransaction(byte[] privateKey, Chain chain, string to, BigInteger amount,
+            BigInteger nonce, BigInteger gasPrice,
+            BigInteger gasLimit, string data)
+        {
+            return SignTransaction(privateKey, (int)chain, to, amount, nonce, gasPrice, gasLimit, data);
+        }
+
+        public string SignTransaction(byte[] privateKey, BigInteger chainId, string to, BigInteger amount,
+            BigInteger nonce, BigInteger gasPrice,
+            BigInteger gasLimit, string data)
+        {
+            var transaction = new TransactionChainId(to, amount, nonce, gasPrice, gasLimit, data, chainId);
+            return SignTransaction(privateKey, transaction);
+        }
+
+        private string SignTransaction(byte[] privateKey, Transaction transaction)
+        {
+            transaction.Sign(new EthECKey(privateKey, true));
+            return transaction.GetRLPEncoded().ToHex();
+        }
+
+        private string SignTransaction(byte[] privateKey, TransactionChainId transaction)
+        {
+            transaction.Sign(new EthECKey(privateKey, true));
+            return transaction.GetRLPEncoded().ToHex();
+        }
+
+#if !DOTNET35
+        private async Task<string> SignTransactionAsync(IEthExternalSigner externalSigner, Transaction transaction)
+        {
+            await transaction.SignExternallyAsync(externalSigner).ConfigureAwait(false);
+            return transaction.GetRLPEncoded().ToHex();
+        }
+
+        private async Task<string> SignTransactionAsync(IEthExternalSigner externalSigner, TransactionChainId transaction)
+        {
+            await transaction.SignExternallyAsync(externalSigner).ConfigureAwait(false);
+            return transaction.GetRLPEncoded().ToHex();
+        }
+
+
+        public Task<string> SignTransactionAsync(IEthExternalSigner externalSigner, string to, BigInteger amount, BigInteger nonce)
+        {
+            var transaction = new Transaction(to, amount, nonce);
+            return SignTransactionAsync(externalSigner, transaction);
+        }
+
+        public Task<string> SignTransactionAsync(IEthExternalSigner externalSigner, string to, BigInteger amount, BigInteger nonce, string data)
+        {
+            var transaction = new Transaction(to, amount, nonce, data);
+            return SignTransactionAsync(externalSigner, transaction);
+        }
+
+        public Task<string> SignTransactionAsync(IEthExternalSigner externalSigner, string to, BigInteger amount, BigInteger nonce,
+            BigInteger gasPrice,
+            BigInteger gasLimit)
+        {
+            var transaction = new Transaction(to, amount, nonce, gasPrice, gasLimit);
+            return SignTransactionAsync(externalSigner, transaction);
+        }
+
+        public Task<string> SignTransactionAsync(IEthExternalSigner externalSigner, string to, BigInteger amount, BigInteger nonce,
+            BigInteger gasPrice,
+            BigInteger gasLimit, string data)
+        {
+            var transaction = new Transaction(to, amount, nonce, gasPrice, gasLimit, data);
+            return SignTransactionAsync(externalSigner, transaction);
+        }
+
+       public Task<string> SignTransactionAsync(IEthExternalSigner externalSigner, Chain chain, string to, BigInteger amount,
+            BigInteger nonce)
+        {
+            return SignTransactionAsync(externalSigner, (int)chain, to, amount, nonce);
+        }
+
+        public Task<string> SignTransactionAsync(IEthExternalSigner externalSigner, BigInteger chainId, string to, BigInteger amount,
+            BigInteger nonce)
+        {
+            var transaction = new TransactionChainId(to, amount, nonce, chainId);
+            return SignTransactionAsync(externalSigner, transaction);
+        }
+
+        public Task<string> SignTransactionAsync(IEthExternalSigner externalSigner, Chain chain, string to, BigInteger amount,
+            BigInteger nonce, string data)
+        {
+            return SignTransactionAsync(externalSigner, (int)chain, to, amount, nonce, data);
+        }
+
+        public Task<string> SignTransactionAsync(IEthExternalSigner externalSigner, BigInteger chainId, string to, BigInteger amount,
+            BigInteger nonce, string data)
+        {
+            var transaction = new TransactionChainId(to, amount, nonce, data, chainId);
+            return SignTransactionAsync(externalSigner, transaction);
+        }
+
+        public Task<string> SignTransactionAsync(IEthExternalSigner externalSigner, Chain chain, string to, BigInteger amount,
+            BigInteger nonce, BigInteger gasPrice,
+            BigInteger gasLimit)
+        {
+            return SignTransactionAsync(externalSigner, (int)chain, to, amount, nonce, gasPrice, gasLimit);
+        }
+
+        public Task<string> SignTransactionAsync(IEthExternalSigner externalSigner, BigInteger chainId, string to, BigInteger amount,
+            BigInteger nonce, BigInteger gasPrice,
+            BigInteger gasLimit)
+        {
+            var transaction = new TransactionChainId(to, amount, nonce, gasPrice, gasLimit, chainId);
+            return SignTransactionAsync(externalSigner, transaction);
+        }
+
+        public Task<string> SignTransactionAsync(IEthExternalSigner externalSigner, Chain chain, string to, BigInteger amount,
+            BigInteger nonce, BigInteger gasPrice,
+            BigInteger gasLimit, string data)
+        {
+            return SignTransactionAsync(externalSigner, (int)chain, to, amount, nonce, gasPrice, gasLimit, data);
+        }
+
+        public Task<string> SignTransactionAsync(IEthExternalSigner externalSigner, BigInteger chainId, string to, BigInteger amount,
+            BigInteger nonce, BigInteger gasPrice,
+            BigInteger gasLimit, string data)
+        {
+            var transaction = new TransactionChainId(to, amount, nonce, gasPrice, gasLimit, data, chainId);
+            return SignTransactionAsync(externalSigner, transaction);
+        }
+#endif
+
+    }
+}

--- a/Phantasma.Ethereum/Util/AddressExtensions.cs
+++ b/Phantasma.Ethereum/Util/AddressExtensions.cs
@@ -1,0 +1,54 @@
+﻿namespace Nethereum.Util
+{
+    public static class AddressExtensions
+    {
+        public static string ConvertToEthereumChecksumAddress(this string address)
+        {
+           return AddressUtil.Current.ConvertToChecksumAddress(address);
+        }
+
+        public static bool IsEthereumChecksumAddress(this string address)
+        {
+            return AddressUtil.Current.IsChecksumAddress(address);
+        }
+
+
+        /// <summary>
+        /// Validates if the hex string is 40 alphanumeric characters
+        /// </summary>
+        public static bool IsValidEthereumAddressHexFormat(this string address)
+        {
+            return AddressUtil.Current.IsValidEthereumAddressHexFormat(address);
+        }
+
+        public static bool IsValidEthereumAddressLength(this string address)
+        {
+            return AddressUtil.Current.IsValidAddressLength(address);
+        }
+
+        public static bool IsTheSameAddress(this string address, string otherAddress)
+        {
+            return AddressUtil.Current.AreAddressesTheSame(address, otherAddress);
+        }
+
+        public static bool IsAnEmptyAddress(this string address)
+        {
+            return AddressUtil.Current.IsAnEmptyAddress(address);
+        }
+
+        public static bool IsNotAnEmptyAddress(this string address)
+        {
+            return AddressUtil.Current.IsNotAnEmptyAddress(address);
+        }
+
+        public static string AddressValueOrEmpty(this string address)
+        {
+            return AddressUtil.Current.AddressValueOrEmpty(address);
+        }
+
+        public static bool IsEmptyOrEqualsAddress(this string address1, string candidate)
+        {
+            return AddressUtil.Current.IsEmptyOrEqualsAddress(address1, candidate);
+        }
+    }
+}

--- a/Phantasma.Ethereum/Util/AddressUtil.cs
+++ b/Phantasma.Ethereum/Util/AddressUtil.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Nethereum.Hex.HexConvertors.Extensions;
+
+namespace Nethereum.Util
+{
+    public class UniqueAddressList : HashSet<string>
+    {
+        public UniqueAddressList() : base(new AddressEqualityComparer()) { }
+    }
+
+
+    public class AddressEqualityComparer : IEqualityComparer<string>
+    {
+        public bool Equals(string x, string y)
+        {
+            return x.IsTheSameAddress(y);
+        }
+
+        public int GetHashCode(string obj)
+        {
+            return -1;
+        }
+    }
+
+    public class AddressUtil
+    {
+        private static AddressUtil _current;
+        public const string AddressEmptyAsHex = "0x0";
+
+        public static AddressUtil Current
+        {
+            get
+            {
+                if (_current == null) _current = new AddressUtil();
+                return _current;
+            }
+        }
+
+        public bool IsAnEmptyAddress(string address)
+        {
+#if !NET35
+            if (string.IsNullOrWhiteSpace(address))
+                return true;
+#else
+            if (string.IsNullOrEmpty(address)) return true;
+#endif
+                return address == AddressEmptyAsHex;
+
+        }
+
+        public bool IsNotAnEmptyAddress(string address)
+        {
+            return !IsAnEmptyAddress(address);
+
+        }
+
+        public string AddressValueOrEmpty(string address)
+        {
+            return address.IsAnEmptyAddress() ? AddressEmptyAsHex : address;
+        }
+
+        public bool IsEmptyOrEqualsAddress(string address1, string candidate)
+        {
+            return IsAnEmptyAddress(address1) || AreAddressesTheSame(address1,candidate);
+        }
+
+        public bool AreAddressesTheSame(string address1, string address2)
+        {
+            if (address1.IsAnEmptyAddress() && address2.IsAnEmptyAddress()) return true;
+            if (address1.IsAnEmptyAddress() || address2.IsAnEmptyAddress()) return false;
+            //simple string comparison as opposed to use big integer comparison
+            return string.Equals(address1.EnsureHexPrefix()?.ToLowerInvariant(), address2.EnsureHexPrefix()?.ToLowerInvariant(), StringComparison.OrdinalIgnoreCase); 
+        }
+
+        public string ConvertToChecksumAddress(string address)
+        {
+            address = address.ToLower().RemoveHexPrefix();
+            var addressHash = new Sha3Keccack().CalculateHash(address);
+            var checksumAddress = "0x";
+
+            for (var i = 0; i < address.Length; i++)
+                if (int.Parse(addressHash[i].ToString(), NumberStyles.HexNumber) > 7)
+                    checksumAddress += address[i].ToString().ToUpper();
+                else
+                    checksumAddress += address[i];
+            return checksumAddress;
+        }
+
+        public string ConvertToValid20ByteAddress(string address)
+        {
+            if (address == null) address = string.Empty;
+            address = address.RemoveHexPrefix();
+            return address.PadLeft(40, '0').EnsureHexPrefix();
+        }
+
+        public bool IsValidAddressLength(string address)
+        {
+            if (string.IsNullOrEmpty(address)) return false;
+            address = address.RemoveHexPrefix();
+            return address.Length == 40;
+        }
+
+        /// <summary>
+        /// Validates if the hex string is 40 alphanumeric characters
+        /// </summary>
+        public bool IsValidEthereumAddressHexFormat(string address)
+        {
+            if (string.IsNullOrEmpty(address)) return false;
+            return address.HasHexPrefix() && IsValidAddressLength(address) &&
+                   address.IsHex();
+        }
+
+        public bool IsChecksumAddress(string address)
+        {
+            if (string.IsNullOrEmpty(address)) return false;
+            address = address.RemoveHexPrefix();
+            var addressHash = new Sha3Keccack().CalculateHash(address.ToLower());
+
+            for (var i = 0; i < 40; i++)
+            {
+                var value = int.Parse(addressHash[i].ToString(), NumberStyles.HexNumber);
+                // the nth letter should be uppercase if the nth digit of casemap is 1
+                if (value > 7 && address[i].ToString().ToUpper() != address[i].ToString() ||
+                    value <= 7 && address[i].ToString().ToLower() != address[i].ToString())
+                    return false;
+            }
+            return true;
+        }
+    }
+}

--- a/Phantasma.Ethereum/Util/BigDecimal.Formatter.cs
+++ b/Phantasma.Ethereum/Util/BigDecimal.Formatter.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace Nethereum.Util {
+    internal static class BigDecimalFormatter {
+        public static string ToCurrencyString(this BigDecimal value, int maxDigits, NumberFormatInfo format) {
+            value.Normalize();
+
+            if (maxDigits < 0)
+                maxDigits = format.CurrencyDecimalDigits;
+
+            BigDecimal rounded = value.RoundAwayFromZero(significantDigits: maxDigits);
+            var digits = rounded.GetDigits(out int exponent);
+            var result = new StringBuilder();
+            NumberFormatting.FormatCurrency(result,
+                rounded.Mantissa < 0, digits, exponent,
+                maxDigits: maxDigits, info: format);
+            return result.ToString();
+        }
+
+        internal static IList<byte> GetDigits(this BigDecimal value, out int exponent) {
+            var nonNegativeMantissa = value.Mantissa < 0 ? -value.Mantissa : value.Mantissa;
+            var result = new List<byte>();
+            while (nonNegativeMantissa > 0) {
+                result.Add((byte)(nonNegativeMantissa % 10 + '0'));
+                nonNegativeMantissa /= 10;
+            }
+            result.Reverse();
+            exponent = value.Exponent;
+            return result;
+        }
+    }
+}

--- a/Phantasma.Ethereum/Util/BigDecimal.cs
+++ b/Phantasma.Ethereum/Util/BigDecimal.cs
@@ -1,0 +1,427 @@
+﻿using System;
+using System.Globalization;
+using System.Numerics;
+
+namespace Nethereum.Util
+{
+    /// BigNumber based on the original http://uberscraper.blogspot.co.uk/2013/09/c-bigdecimal-class-from-stackoverflow.html
+    /// which was inspired by http://stackoverflow.com/a/4524254
+    /// Original Author: Jan Christoph Bernack (contact: jc.bernack at googlemail.com)
+    /// Changes JB: Added parse, Fix Normalise, Added Floor, New ToString, Change Equals (normalise to validate first), Change Casting to avoid overflows (even if might be slower), Added Normalise Bigger than zero, test on operations, parsing, casting, and other test coverage for ethereum unit conversions
+    /// Changes KJ: Added Culture formatting
+    /// http://stackoverflow.com/a/13813535/956364" />
+    /// <summary>
+    ///     Arbitrary precision Decimal.
+    ///     All operations are exact, except for division.
+    ///     Division never determines more digits than the given precision of 50.
+    /// </summary>
+    public struct BigDecimal : IComparable, IComparable<BigDecimal>
+    {
+        /// <summary>
+        ///     Sets the maximum precision of division operations.
+        ///     If AlwaysTruncate is set to true all operations are affected.
+        /// </summary>
+        public const int Precision = 50;
+
+        public BigDecimal(BigDecimal bigDecimal, bool alwaysTruncate = false) : this(bigDecimal.Mantissa,
+            bigDecimal.Exponent, alwaysTruncate)
+        {
+        }
+
+        public BigDecimal(decimal value, bool alwaysTruncate = false) : this((BigDecimal) value, alwaysTruncate)
+        {
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="mantissa"></param>
+        /// <param name="exponent">
+        ///     The number of decimal units for example (-18). A positive value will be normalised as 10 ^
+        ///     exponent
+        /// </param>
+        /// <param name="alwaysTruncate">
+        ///     Specifies whether the significant digits should be truncated to the given precision after
+        ///     each operation.
+        /// </param>
+        public BigDecimal(BigInteger mantissa, int exponent, bool alwaysTruncate = false) : this()
+        {
+            Mantissa = mantissa;
+            Exponent = exponent;
+            NormaliseExponentBiggerThanZero();
+            Normalize();
+            if (alwaysTruncate)
+                Truncate();
+        }
+
+        public BigInteger Mantissa { get; internal set; }
+        public int Exponent { get; internal set; }
+
+        public int CompareTo(object obj)
+        {
+            if (ReferenceEquals(obj, null) || !(obj is BigDecimal))
+                throw new ArgumentException();
+            return CompareTo((BigDecimal) obj);
+        }
+
+        public int CompareTo(BigDecimal other)
+        {
+            return this < other ? -1 : (this > other ? 1 : 0);
+        }
+
+        public void NormaliseExponentBiggerThanZero()
+        {
+            if (Exponent > 0)
+            {
+                Mantissa = Mantissa * BigInteger.Pow(10, Exponent);
+                Exponent = 0;
+            }
+        }
+
+        /// <summary>
+        ///     Removes trailing zeros on the mantissa
+        /// </summary>
+        public void Normalize()
+        {
+            if (Exponent == 0) return;
+
+            if (Mantissa.IsZero)
+            {
+                Exponent = 0;
+            }
+            else
+            {
+                BigInteger remainder = 0;
+                while (remainder == 0)
+                {
+                    var shortened = BigInteger.DivRem(Mantissa, 10, out remainder);
+                    if (remainder != 0)
+                        continue;
+                    Mantissa = shortened;
+                    Exponent++;
+                }
+                NormaliseExponentBiggerThanZero();
+            }
+        }
+
+        /// <summary>
+        ///     Truncate the number to the given precision by removing the least significant digits.
+        /// </summary>
+        /// <returns>The truncated number</returns>
+        internal BigDecimal Truncate(int precision = Precision)
+        {
+            // copy this instance (remember its a struct)
+            var shortened = this;
+            // save some time because the number of digits is not needed to remove trailing zeros
+            shortened.Normalize();
+            // remove the least significant digits, as long as the number of digits is higher than the given Precision
+            while (shortened.Mantissa.NumberOfDigits() > precision)
+            {
+                shortened.Mantissa /= 10;
+                shortened.Exponent++;
+            }
+            return shortened;
+        }
+
+        /// <summary>
+        /// Rounds the number to the specified amount of significant digits.
+        /// Midpoints (like 0.5 or -0.5) are rounded away from 0 (e.g. to 1 and -1 respectively).
+        /// </summary>
+        public BigDecimal RoundAwayFromZero(int significantDigits) {
+            if (significantDigits < 0 || significantDigits > 2_000_000_000)
+                throw new ArgumentOutOfRangeException(paramName: nameof(significantDigits));
+
+            if (Exponent >= -significantDigits) return this;
+
+            bool negative = this.Mantissa < 0;
+            var shortened = negative ? -this : this;
+            shortened.Normalize();
+
+            while (shortened.Exponent < -significantDigits) {
+                shortened.Mantissa = BigInteger.DivRem(shortened.Mantissa, 10, out var rem);
+                shortened.Mantissa += rem >= 5 ? +1 : 0;
+                shortened.Exponent++;
+            }
+
+            return negative ? -shortened : shortened;
+        }
+
+        /// <summary>
+        ///     Truncate the number, removing all decimal digits.
+        /// </summary>
+        /// <returns>The truncated number</returns>
+        public BigDecimal Floor()
+        {
+            return Truncate(Mantissa.NumberOfDigits() + Exponent);
+        }
+
+        private static int NumberOfDigits(BigInteger value)
+        {
+            return value.NumberOfDigits();
+        }
+
+        public override string ToString()
+        {
+            Normalize();
+            var s = Mantissa.ToString();
+            if (Exponent != 0)
+            {
+                var decimalPos = s.Length + Exponent;
+                if (decimalPos < s.Length)
+                    if (decimalPos >= 0)
+                        s = s.Insert(decimalPos, decimalPos == 0 ? "0." : ".");
+                    else
+                        s = "0." + s.PadLeft(decimalPos * -1 + s.Length, '0');
+                else
+                    s = s.PadRight(decimalPos, '0');
+            }
+            return s;
+        }
+
+        public bool Equals(BigDecimal other)
+        {
+            var first = this;
+            var second = other;
+            first.Normalize();
+            second.Normalize();
+            return second.Mantissa.Equals(first.Mantissa) && second.Exponent == first.Exponent;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+                return false;
+            return obj is BigDecimal && Equals((BigDecimal) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (Mantissa.GetHashCode() * 397) ^ Exponent;
+            }
+        }
+
+        #region Conversions
+
+        public static implicit operator BigDecimal(int value)
+        {
+            return new BigDecimal(value, 0);
+        }
+
+        public static implicit operator BigDecimal(double value)
+        {
+            var mantissa = (BigInteger) value;
+            var exponent = 0;
+            double scaleFactor = 1;
+            while (Math.Abs(value * scaleFactor - (double) mantissa) > 0)
+            {
+                exponent -= 1;
+                scaleFactor *= 10;
+                mantissa = (BigInteger) (value * scaleFactor);
+            }
+            return new BigDecimal(mantissa, exponent);
+        }
+
+        public static implicit operator BigDecimal(decimal value)
+        {
+            var mantissa = (BigInteger) value;
+            var exponent = 0;
+            decimal scaleFactor = 1;
+            while ((decimal) mantissa != value * scaleFactor)
+            {
+                exponent -= 1;
+                scaleFactor *= 10;
+                mantissa = (BigInteger) (value * scaleFactor);
+            }
+            return new BigDecimal(mantissa, exponent);
+        }
+
+        public static explicit operator double(BigDecimal value)
+        {
+            return double.Parse(value.ToString(), CultureInfo.InvariantCulture);
+        }
+
+        public static explicit operator float(BigDecimal value)
+        {
+            return float.Parse(value.ToString(), CultureInfo.InvariantCulture);
+        }
+
+        public static explicit operator decimal(BigDecimal value)
+        {
+            return decimal.Parse(value.ToString(), CultureInfo.InvariantCulture);
+        }
+
+        public static explicit operator int(BigDecimal value)
+        {
+            return Convert.ToInt32((decimal) value);
+        }
+
+        public static explicit operator uint(BigDecimal value)
+        {
+            return Convert.ToUInt32((decimal) value);
+        }
+
+        #endregion
+
+        #region Operators
+
+        public static BigDecimal operator +(BigDecimal value)
+        {
+            return value;
+        }
+
+        public static BigDecimal operator -(BigDecimal value)
+        {
+            value.Mantissa *= -1;
+            return value;
+        }
+
+        public static BigDecimal operator ++(BigDecimal value)
+        {
+            return value + 1;
+        }
+
+        public static BigDecimal operator --(BigDecimal value)
+        {
+            return value - 1;
+        }
+
+        public static BigDecimal operator +(BigDecimal left, BigDecimal right)
+        {
+            return Add(left, right);
+        }
+
+        public static BigDecimal operator -(BigDecimal left, BigDecimal right)
+        {
+            return Add(left, -right);
+        }
+
+        private static BigDecimal Add(BigDecimal left, BigDecimal right)
+        {
+            return left.Exponent > right.Exponent
+                ? new BigDecimal(AlignExponent(left, right) + right.Mantissa, right.Exponent)
+                : new BigDecimal(AlignExponent(right, left) + left.Mantissa, left.Exponent);
+        }
+
+        public static BigDecimal operator *(BigDecimal left, BigDecimal right)
+        {
+            return new BigDecimal(left.Mantissa * right.Mantissa, left.Exponent + right.Exponent);
+        }
+
+        public static BigDecimal operator /(BigDecimal dividend, BigDecimal divisor)
+        {
+            var exponentChange = Precision - (NumberOfDigits(dividend.Mantissa) - NumberOfDigits(divisor.Mantissa));
+            if (exponentChange < 0)
+                exponentChange = 0;
+            dividend.Mantissa *= BigInteger.Pow(10, exponentChange);
+            return new BigDecimal(dividend.Mantissa / divisor.Mantissa,
+                dividend.Exponent - divisor.Exponent - exponentChange);
+        }
+
+        public static bool operator ==(BigDecimal left, BigDecimal right)
+        {
+            return left.Exponent == right.Exponent && left.Mantissa == right.Mantissa;
+        }
+
+        public static bool operator !=(BigDecimal left, BigDecimal right)
+        {
+            return left.Exponent != right.Exponent || left.Mantissa != right.Mantissa;
+        }
+
+        public static bool operator <(BigDecimal left, BigDecimal right)
+        {
+            return left.Exponent > right.Exponent
+                ? AlignExponent(left, right) < right.Mantissa
+                : left.Mantissa < AlignExponent(right, left);
+        }
+
+        public static bool operator >(BigDecimal left, BigDecimal right)
+        {
+            return left.Exponent > right.Exponent
+                ? AlignExponent(left, right) > right.Mantissa
+                : left.Mantissa > AlignExponent(right, left);
+        }
+
+        public static bool operator <=(BigDecimal left, BigDecimal right)
+        {
+            return left.Exponent > right.Exponent
+                ? AlignExponent(left, right) <= right.Mantissa
+                : left.Mantissa <= AlignExponent(right, left);
+        }
+
+        public static bool operator >=(BigDecimal left, BigDecimal right)
+        {
+            return left.Exponent > right.Exponent
+                ? AlignExponent(left, right) >= right.Mantissa
+                : left.Mantissa >= AlignExponent(right, left);
+        }
+
+        public static BigDecimal Parse(string value)
+        {
+            //todo culture format
+            var decimalCharacter = ".";
+            var indexOfDecimal = value.IndexOf(".");
+            var exponent = 0;
+            if (indexOfDecimal != -1)
+                exponent = (value.Length - (indexOfDecimal + 1)) * -1;
+            var mantissa = BigInteger.Parse(value.Replace(decimalCharacter, ""));
+            return new BigDecimal(mantissa, exponent);
+        }
+
+        /// <summary>
+        ///     Returns the mantissa of value, aligned to the exponent of reference.
+        ///     Assumes the exponent of value is larger than of value.
+        /// </summary>
+        private static BigInteger AlignExponent(BigDecimal value, BigDecimal reference)
+        {
+            return value.Mantissa * BigInteger.Pow(10, value.Exponent - reference.Exponent);
+        }
+
+        #endregion
+
+        #region Additional mathematical functions
+
+        public static BigDecimal Exp(double exponent)
+        {
+            var tmp = (BigDecimal) 1;
+            while (Math.Abs(exponent) > 100)
+            {
+                var diff = exponent > 0 ? 100 : -100;
+                tmp *= Math.Exp(diff);
+                exponent -= diff;
+            }
+            return tmp * Math.Exp(exponent);
+        }
+
+        public static BigDecimal Pow(double basis, double exponent)
+        {
+            var tmp = (BigDecimal) 1;
+            while (Math.Abs(exponent) > 100)
+            {
+                var diff = exponent > 0 ? 100 : -100;
+                tmp *= Math.Pow(basis, diff);
+                exponent -= diff;
+            }
+            return tmp * Math.Pow(basis, exponent);
+        }
+
+        #endregion
+
+        #region Formatting
+
+        public string ToString(string formatSpecifier, IFormatProvider format) {
+            char fmt = NumberFormatting.ParseFormatSpecifier(formatSpecifier, out int digits);
+            if (fmt != 'c' && fmt != 'C')
+                throw new NotImplementedException();
+
+            Normalize();
+            if (Exponent == 0)
+                return Mantissa.ToString(formatSpecifier, format);
+
+            var numberFormatInfo = NumberFormatInfo.GetInstance(format);
+            return BigDecimalFormatter.ToCurrencyString(this, digits, numberFormatInfo);
+        }
+
+        #endregion
+    }
+}

--- a/Phantasma.Ethereum/Util/BigIntegerExtensions.cs
+++ b/Phantasma.Ethereum/Util/BigIntegerExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Globalization;
+using System.Numerics;
+
+namespace Nethereum.Util
+{
+    public static class BigIntegerExtensions
+    {
+        public static int NumberOfDigits(this BigInteger value)
+        {
+            return (value * value.Sign).ToString().Length;
+        }
+
+        public static BigInteger ParseInvariant(string value)
+        {
+            if (value == null) throw new ArgumentNullException(nameof(value));
+
+            return BigInteger.Parse(value, CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/Phantasma.Ethereum/Util/ByteUtil.cs
+++ b/Phantasma.Ethereum/Util/ByteUtil.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Nethereum.Util
+{
+    public static class ByteUtil
+    {
+        public static readonly byte[] EMPTY_BYTE_ARRAY = new byte[0];
+        public static readonly byte[] ZERO_BYTE_ARRAY = {0};
+
+        /// <summary>
+        ///     Creates a copy of bytes and appends b to the end of it
+        /// </summary>
+        public static byte[] AppendByte(byte[] bytes, byte b)
+        {
+            var result = new byte[bytes.Length + 1];
+            Array.Copy(bytes, result, bytes.Length);
+            result[result.Length - 1] = b;
+            return result;
+        }
+
+        public static byte[] Slice(this byte[] org,
+            int start, int end = int.MaxValue)
+        {
+            if (end < 0)
+                end = org.Length + end;
+            start = Math.Max(0, start);
+            end = Math.Max(start, end);
+
+            return org.Skip(start).Take(end - start).ToArray();
+        }
+
+        public static byte[] InitialiseEmptyByteArray(int length)
+        {
+            var returnArray = new byte[length];
+            for (var i = 0; i < length; i++)
+                returnArray[i] = 0x00;
+            return returnArray;
+        }
+
+        public static IEnumerable<byte> MergeToEnum(params byte[][] arrays)
+        {
+            foreach (var a in arrays)
+            foreach (var b in a)
+                yield return b;
+        }
+
+        /// <param name="arrays"> - arrays to merge </param>
+        /// <returns> - merged array </returns>
+        public static byte[] Merge(params byte[][] arrays)
+        {
+            return MergeToEnum(arrays).ToArray();
+        }
+
+        public static byte[] XOR(this byte[] a, byte[] b)
+        {
+            var length = Math.Min(a.Length, b.Length);
+            var result = new byte[length];
+            for (var i = 0; i < length; i++)
+                result[i] = (byte) (a[i] ^ b[i]);
+            return result;
+        }
+    }
+}

--- a/Phantasma.Ethereum/Util/ContractUtils.cs
+++ b/Phantasma.Ethereum/Util/ContractUtils.cs
@@ -1,0 +1,17 @@
+﻿using System.Numerics;
+using Nethereum.Hex.HexConvertors.Extensions;
+using Nethereum.RLP;
+
+namespace Nethereum.Util
+{
+    public static class ContractUtils
+    {
+        public static string CalculateContractAddress(string address, BigInteger nonce)
+        {
+            var sha3 = new Sha3Keccack();
+            return  
+                sha3.CalculateHash(RLP.RLP.EncodeList(RLP.RLP.EncodeElement(address.HexToByteArray()),
+                    RLP.RLP.EncodeElement(nonce.ToBytesForRLPEncoding()))).ToHex().Substring(24);
+        }
+    }
+}

--- a/Phantasma.Ethereum/Util/FormattingExtensions.cs
+++ b/Phantasma.Ethereum/Util/FormattingExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Globalization;
+
+namespace Nethereum.Util {
+    public static class FormattingExtensions
+    {
+        /// <summary>
+        /// Converts formattable value to string in a culture-independent way.
+        /// </summary>
+        public static string ToStringInvariant<T>(this T formattable) where T: IFormattable
+        {
+            if (formattable == null) throw new ArgumentNullException(nameof(formattable));
+
+            return formattable.ToString(null, CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/Phantasma.Ethereum/Util/IWaitStrategy.cs
+++ b/Phantasma.Ethereum/Util/IWaitStrategy.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Nethereum.Utils
+{
+    public interface IWaitStrategy
+    {
+        Task Apply(uint retryCount);
+    }
+}

--- a/Phantasma.Ethereum/Util/NumberFormatting.cs
+++ b/Phantasma.Ethereum/Util/NumberFormatting.cs
@@ -1,0 +1,198 @@
+﻿namespace Nethereum.Util {
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Globalization;
+    using System.Runtime.InteropServices;
+    using System.Text;
+
+    internal static class NumberFormatting {
+        private static readonly string[] s_posCurrencyFormats =
+        {
+            "$#", "#$", "$ #", "# $"
+        };
+
+        private static readonly string[] s_negCurrencyFormats =
+        {
+            "($#)", "-$#", "$-#", "$#-",
+            "(#$)", "-#$", "#-$", "#$-",
+            "-# $", "-$ #", "# $-", "$ #-",
+            "$ -#", "#- $", "($ #)", "(# $)"
+        };
+
+        internal static char ParseFormatSpecifier(string format, out int digits) {
+            char c = default;
+            if (format.Length > 0) {
+                // If the format begins with a symbol, see if it's a standard format
+                // with or without a specified number of digits.
+                c = format[0];
+                if ((uint)(c - 'A') <= 'Z' - 'A' ||
+                    (uint)(c - 'a') <= 'z' - 'a') {
+                    // Fast path for sole symbol, e.g. "D"
+                    if (format.Length == 1) {
+                        digits = -1;
+                        return c;
+                    }
+
+                    if (format.Length == 2) {
+                        // Fast path for symbol and single digit, e.g. "X4"
+                        int d = format[1] - '0';
+                        if ((uint)d < 10) {
+                            digits = d;
+                            return c;
+                        }
+                    } else if (format.Length == 3) {
+                        // Fast path for symbol and double digit, e.g. "F12"
+                        int d1 = format[1] - '0', d2 = format[2] - '0';
+                        if ((uint)d1 < 10 && (uint)d2 < 10) {
+                            digits = d1 * 10 + d2;
+                            return c;
+                        }
+                    }
+
+                    // Fallback for symbol and any length digits.  The digits value must be >= 0 && <= 99,
+                    // but it can begin with any number of 0s, and thus we may need to check more than two
+                    // digits.  Further, for compat, we need to stop when we hit a null char.
+                    int n = 0;
+                    int i = 1;
+                    while (i < format.Length && (((uint)format[i] - '0') < 10) && n < 10) {
+                        n = (n * 10) + format[i++] - '0';
+                    }
+
+                    // If we're at the end of the digits rather than having stopped because we hit something
+                    // other than a digit or overflowed, return the standard format info.
+                    if (i == format.Length || format[i] == '\0') {
+                        digits = n;
+                        return c;
+                    }
+                }
+            }
+
+            // Default empty format to be "G"; custom format is signified with '\0'.
+            digits = -1;
+            return format.Length == 0 || c == '\0' ? // For compat, treat '\0' as the end of the specifier, even if the specifier extends beyond it.
+                'G' :
+                '\0';
+        }
+
+        internal static void FormatCurrency(StringBuilder result,
+            bool isNegative, IList<byte> digits, int exponent,
+            int maxDigits, NumberFormatInfo info) {
+            string fmt = isNegative ?
+                s_negCurrencyFormats[info.CurrencyNegativePattern] :
+                s_posCurrencyFormats[info.CurrencyPositivePattern];
+
+            foreach (char ch in fmt) {
+                switch (ch) {
+                case '#':
+                    FormatFixed(result, digits, exponent,
+                        maxFractionalDigits: maxDigits,
+                        info.CurrencyGroupSizes,
+                        decimalSeparator: info.CurrencyDecimalSeparator,
+                        groupSeparator: info.CurrencyGroupSeparator);
+                    break;
+                case '-':
+                    result.Append(info.NegativeSign);
+                    break;
+                case '$':
+                    result.Append(info.CurrencySymbol);
+                    break;
+                default:
+                    result.Append(ch);
+                    break;
+                }
+            }
+        }
+
+        internal static void FormatFixed(StringBuilder sb, IList<byte> digits, int exponent,
+            int maxFractionalDigits,
+            int[] groupDigits, string decimalSeparator, string groupSeparator) {
+            int digPos = digits.Count+exponent;
+            int digitIndex = 0;
+
+            if (digPos > 0) {
+                if (groupDigits != null) {
+                    Debug.Assert(groupSeparator != null, "Must be null when groupDigits != null");
+                    int groupSizeIndex = 0;               // Index into the groupDigits array.
+                    int bufferSize = digPos;              // The length of the result buffer string.
+                    int groupSize = 0;                    // The current group size.
+
+                    // Find out the size of the string buffer for the result.
+                    if (groupDigits.Length != 0) // You can pass in 0 length arrays
+                    {
+                        int groupSizeCount = groupDigits[groupSizeIndex];   // The current total of group size.
+
+                        while (digPos > groupSizeCount) {
+                            groupSize = groupDigits[groupSizeIndex];
+                            if (groupSize == 0)
+                                break;
+
+                            bufferSize += groupSeparator.Length;
+                            if (groupSizeIndex < groupDigits.Length - 1)
+                                groupSizeIndex++;
+
+                            groupSizeCount += groupDigits[groupSizeIndex];
+                            if (groupSizeCount < 0 || bufferSize < 0)
+                                throw new ArgumentOutOfRangeException(); // If we overflow
+                        }
+
+                        groupSize = groupSizeCount == 0 ? 0 : groupDigits[0]; // If you passed in an array with one entry as 0, groupSizeCount == 0
+                    }
+
+                    groupSizeIndex = 0;
+                    int digitCount = 0;
+                    //int digLength = number.DigitsCount;
+                    int digLength = digits.Count;
+                    int digStart = (digPos < digLength) ? digPos : digLength;
+                    char[] spanPtr = new char[bufferSize];
+                    int p = bufferSize - 1;
+                    for (int i = digPos - 1; i >= 0; i--) {
+                        spanPtr[p--] = (i < digStart) ? (char)(digits[digitIndex + i]) : '0';
+
+                        if (groupSize > 0) {
+                            digitCount++;
+                            if ((digitCount == groupSize) && (i != 0)) {
+                                for (int j = groupSeparator.Length - 1; j >= 0; j--)
+                                    spanPtr[p--] = groupSeparator[j];
+
+                                if (groupSizeIndex < groupDigits.Length - 1) {
+                                    groupSizeIndex++;
+                                    groupSize = groupDigits[groupSizeIndex];
+                                }
+                                digitCount = 0;
+                            }
+                        }
+                    }
+
+                    sb.Append(spanPtr);
+
+                    Debug.Assert(p >= -1, "Underflow");
+                    digitIndex += digStart;
+                } else {
+                    do {
+                        sb.Append(digitIndex < digits.Count ? (char)digits[digitIndex++] : '0');
+                    }
+                    while (--digPos > 0);
+                }
+            } else {
+                sb.Append('0');
+            }
+
+            if (maxFractionalDigits > 0) {
+                Debug.Assert(decimalSeparator != null);
+                sb.Append(decimalSeparator);
+                if ((digPos < 0) && (maxFractionalDigits > 0)) {
+                    int zeroes = Math.Min(-digPos, maxFractionalDigits);
+                    sb.Append('0', zeroes);
+                    digPos += zeroes;
+                    maxFractionalDigits -= zeroes;
+                }
+
+                while (maxFractionalDigits > 0) {
+                    sb.Append((digitIndex < digits.Count) ? (char)digits[digitIndex++] : '0');
+                    maxFractionalDigits--;
+                }
+            }
+        }
+    }
+}

--- a/Phantasma.Ethereum/Util/PredicateBuilder.cs
+++ b/Phantasma.Ethereum/Util/PredicateBuilder.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Collections.Generic;
+
+namespace Nethereum.Util
+{
+    //Predicate Builder from Joseph and Ben Albahari http://www.albahari.com/nutshell/predicatebuilder.aspx
+    public static class PredicateBuilder
+    {
+        public static Expression<Func<T, bool>> True<T>() { return f => true; }
+        public static Expression<Func<T, bool>> False<T>() { return f => false; }
+
+        public static Expression<Func<T, bool>> Or<T>(this Expression<Func<T, bool>> expr1,
+            Expression<Func<T, bool>> expr2)
+        {
+            var invokedExpr = Expression.Invoke(expr2, expr1.Parameters.Cast<Expression>());
+            return Expression.Lambda<Func<T, bool>>
+                (Expression.OrElse(expr1.Body, invokedExpr), expr1.Parameters);
+        }
+
+        public static Expression<Func<T, bool>> And<T>(this Expression<Func<T, bool>> expr1,
+            Expression<Func<T, bool>> expr2)
+        {
+            var invokedExpr = Expression.Invoke(expr2, expr1.Parameters.Cast<Expression>());
+            return Expression.Lambda<Func<T, bool>>
+                (Expression.AndAlso(expr1.Body, invokedExpr), expr1.Parameters);
+        }
+    }
+}

--- a/Phantasma.Ethereum/Util/Sha3Keccack.cs
+++ b/Phantasma.Ethereum/Util/Sha3Keccack.cs
@@ -1,0 +1,34 @@
+﻿using System.Linq;
+using System.Text;
+using Nethereum.Hex.HexConvertors.Extensions;
+using Org.BouncyCastle.Crypto.Digests;
+
+namespace Nethereum.Util
+{
+    public class Sha3Keccack
+    {
+        public static Sha3Keccack Current { get; } = new Sha3Keccack();
+
+        public string CalculateHash(string value)
+        {
+            var input = Encoding.UTF8.GetBytes(value);
+            var output = CalculateHash(input);
+            return output.ToHex();
+        }
+
+        public string CalculateHashFromHex(params string[] hexValues)
+        {
+            var joinedHex = string.Join("", hexValues.Select(x => x.RemoveHexPrefix()).ToArray());
+            return CalculateHash(joinedHex.HexToByteArray()).ToHex();
+        }
+
+        public byte[] CalculateHash(byte[] value)
+        {
+            var digest = new KeccakDigest(256);
+            var output = new byte[digest.GetDigestSize()];
+            digest.BlockUpdate(value, 0, value.Length);
+            digest.DoFinal(output, 0);
+            return output;
+        }
+    }
+}

--- a/Phantasma.Ethereum/Util/TransactionUtils.cs
+++ b/Phantasma.Ethereum/Util/TransactionUtils.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Text;
+using System;
+
+namespace Nethereum.Util
+{
+    public static class TransactionUtils
+    {
+        public static string CalculateTransactionHash(string rawSignedTransaction)
+        {
+            var sha3 = new Sha3Keccack();
+            return sha3.CalculateHashFromHex(rawSignedTransaction);
+        }
+    }
+
+    public class UniqueTransactionHashList : HashSet<string>
+    {
+        public UniqueTransactionHashList() : base(StringComparer.OrdinalIgnoreCase) { }
+    }
+}

--- a/Phantasma.Ethereum/Util/UnitConversion.cs
+++ b/Phantasma.Ethereum/Util/UnitConversion.cs
@@ -1,0 +1,274 @@
+using System;
+using System.Numerics;
+
+namespace Nethereum.Util
+{
+    public class UnitConversion
+    {
+        public enum EthUnit
+        {
+            Wei,
+            Kwei,
+            Ada,
+            Femtoether,
+            Mwei,
+            Babbage,
+            Picoether,
+            Gwei,
+            Shannon,
+            Nanoether,
+            Nano,
+            Szabo,
+            Microether,
+            Micro,
+            Finney,
+            Milliether,
+            Milli,
+            Ether,
+            Kether,
+            Grand,
+            Einstein,
+            Mether,
+            Gether,
+            Tether
+        }
+
+        private static UnitConversion convert;
+
+        public static UnitConversion Convert
+        {
+            get
+            {
+                if (convert == null) convert = new UnitConversion();
+                return convert;
+            }
+        }
+
+        /// <summary>
+        ///     Converts from wei to a unit, NOTE: When the total number of digits is bigger than 29 they will be rounded the less
+        ///     significant digits
+        /// </summary>
+        public decimal FromWei(BigInteger value, BigInteger toUnit)
+        {
+            return FromWei(value, GetEthUnitValueLength(toUnit));
+        }
+
+        /// <summary>
+        ///     Converts from wei to a unit, NOTE: When the total number of digits is bigger than 29 they will be rounded the less
+        ///     significant digits
+        /// </summary>
+        public decimal FromWei(BigInteger value, EthUnit toUnit = EthUnit.Ether)
+        {
+            return FromWei(value, GetEthUnitValue(toUnit));
+        }
+
+        /// <summary>
+        ///     Converts from wei to a unit, NOTE: When the total number of digits is bigger than 29 they will be rounded the less
+        ///     significant digits
+        /// </summary>
+        public decimal FromWei(BigInteger value, int decimalPlacesToUnit)
+        {
+            return (decimal) new BigDecimal(value, decimalPlacesToUnit * -1);
+        }
+
+        public BigDecimal FromWeiToBigDecimal(BigInteger value, int decimalPlacesToUnit)
+        {
+            return new BigDecimal(value, decimalPlacesToUnit * -1);
+        }
+
+        public BigDecimal FromWeiToBigDecimal(BigInteger value, EthUnit toUnit = EthUnit.Ether)
+        {
+            return FromWeiToBigDecimal(value, GetEthUnitValue(toUnit));
+        }
+
+        public BigDecimal FromWeiToBigDecimal(BigInteger value, BigInteger toUnit)
+        {
+            return FromWeiToBigDecimal(value, GetEthUnitValueLength(toUnit));
+        }
+
+        private int GetEthUnitValueLength(BigInteger unitValue)
+        {
+            return unitValue.ToStringInvariant().Length - 1;
+        }
+
+        public BigInteger GetEthUnitValue(EthUnit ethUnit)
+        {
+            switch (ethUnit)
+            {
+                case EthUnit.Wei:
+                    return BigIntegerExtensions.ParseInvariant("1");
+                case EthUnit.Kwei:
+                    return BigIntegerExtensions.ParseInvariant("1000");
+                case EthUnit.Babbage:
+                    return BigIntegerExtensions.ParseInvariant("1000");
+                case EthUnit.Femtoether:
+                    return BigIntegerExtensions.ParseInvariant("1000");
+                case EthUnit.Mwei:
+                    return BigIntegerExtensions.ParseInvariant("1000000");
+                case EthUnit.Picoether:
+                    return BigIntegerExtensions.ParseInvariant("1000000");
+                case EthUnit.Gwei:
+                    return BigIntegerExtensions.ParseInvariant("1000000000");
+                case EthUnit.Shannon:
+                    return BigIntegerExtensions.ParseInvariant("1000000000");
+                case EthUnit.Nanoether:
+                    return BigIntegerExtensions.ParseInvariant("1000000000");
+                case EthUnit.Nano:
+                    return BigIntegerExtensions.ParseInvariant("1000000000");
+                case EthUnit.Szabo:
+                    return BigIntegerExtensions.ParseInvariant("1000000000000");
+                case EthUnit.Microether:
+                    return BigIntegerExtensions.ParseInvariant("1000000000000");
+                case EthUnit.Micro:
+                    return BigIntegerExtensions.ParseInvariant("1000000000000");
+                case EthUnit.Finney:
+                    return BigIntegerExtensions.ParseInvariant("1000000000000000");
+                case EthUnit.Milliether:
+                    return BigIntegerExtensions.ParseInvariant("1000000000000000");
+                case EthUnit.Milli:
+                    return BigIntegerExtensions.ParseInvariant("1000000000000000");
+                case EthUnit.Ether:
+                    return BigIntegerExtensions.ParseInvariant("1000000000000000000");
+                case EthUnit.Kether:
+                    return BigIntegerExtensions.ParseInvariant("1000000000000000000000");
+                case EthUnit.Grand:
+                    return BigIntegerExtensions.ParseInvariant("1000000000000000000000");
+                case EthUnit.Einstein:
+                    return BigIntegerExtensions.ParseInvariant("1000000000000000000000");
+                case EthUnit.Mether:
+                    return BigIntegerExtensions.ParseInvariant("1000000000000000000000000");
+                case EthUnit.Gether:
+                    return BigIntegerExtensions.ParseInvariant("1000000000000000000000000000");
+                case EthUnit.Tether:
+                    return BigIntegerExtensions.ParseInvariant("1000000000000000000000000000000");
+            }
+            throw new NotImplementedException();
+        }
+
+
+        public bool TryValidateUnitValue(BigInteger ethUnit)
+        {
+            if (ethUnit.ToStringInvariant().Trim('0') == "1") return true;
+            throw new Exception("Invalid unit value, it should be a power of 10 ");
+        }
+
+        public BigInteger ToWeiFromUnit(decimal amount, BigInteger fromUnit)
+        {
+            return ToWeiFromUnit((BigDecimal) amount, fromUnit);
+        }
+
+        public BigInteger ToWeiFromUnit(BigDecimal amount, BigInteger fromUnit)
+        {
+            TryValidateUnitValue(fromUnit);
+            var bigDecimalFromUnit = new BigDecimal(fromUnit, 0);
+            var conversion = amount * bigDecimalFromUnit;
+            return conversion.Floor().Mantissa;
+        }
+
+        public BigInteger ToWei(BigDecimal amount, EthUnit fromUnit = EthUnit.Ether)
+        {
+            return ToWeiFromUnit(amount, GetEthUnitValue(fromUnit));
+        }
+
+        public BigInteger ToWei(BigDecimal amount, int decimalPlacesFromUnit)
+        {
+            if (decimalPlacesFromUnit == 0) ToWei(amount, 1);
+            return ToWeiFromUnit(amount, BigInteger.Pow(10, decimalPlacesFromUnit));
+        }
+
+        public BigInteger ToWei(decimal amount, int decimalPlacesFromUnit)
+        {
+            if (decimalPlacesFromUnit == 0) ToWei(amount, 1);
+            return ToWeiFromUnit(amount, BigInteger.Pow(10, decimalPlacesFromUnit));
+        }
+
+
+        public BigInteger ToWei(decimal amount, EthUnit fromUnit = EthUnit.Ether)
+        {
+            return ToWeiFromUnit(amount, GetEthUnitValue(fromUnit));
+        }
+
+
+        public BigInteger ToWei(BigInteger value, EthUnit fromUnit = EthUnit.Ether)
+        {
+            return value * GetEthUnitValue(fromUnit);
+        }
+
+        public BigInteger ToWei(int value, EthUnit fromUnit = EthUnit.Ether)
+        {
+            return ToWei(new BigInteger(value), fromUnit);
+        }
+
+        public BigInteger ToWei(double value, EthUnit fromUnit = EthUnit.Ether)
+        {
+            return ToWei(System.Convert.ToDecimal(value), fromUnit);
+        }
+
+        public BigInteger ToWei(float value, EthUnit fromUnit = EthUnit.Ether)
+        {
+            return ToWei(System.Convert.ToDecimal(value), fromUnit);
+        }
+
+        public BigInteger ToWei(long value, EthUnit fromUnit = EthUnit.Ether)
+        {
+            return ToWei(new BigInteger(value), fromUnit);
+        }
+
+        public BigInteger ToWei(string value, EthUnit fromUnit = EthUnit.Ether)
+        {
+            return ToWei(decimal.Parse(value), fromUnit);
+        }
+
+        private BigInteger CalculateNumberOfDecimalPlaces(double value, int maxNumberOfDecimals,
+            int currentNumberOfDecimals = 0)
+        {
+            return CalculateNumberOfDecimalPlaces(System.Convert.ToDecimal(value), maxNumberOfDecimals,
+                currentNumberOfDecimals);
+        }
+
+        private BigInteger CalculateNumberOfDecimalPlaces(float value, int maxNumberOfDecimals,
+            int currentNumberOfDecimals = 0)
+        {
+            return CalculateNumberOfDecimalPlaces(System.Convert.ToDecimal(value), maxNumberOfDecimals,
+                currentNumberOfDecimals);
+        }
+
+        private int CalculateNumberOfDecimalPlaces(decimal value, int maxNumberOfDecimals,
+            int currentNumberOfDecimals = 0)
+        {
+            if (currentNumberOfDecimals == 0)
+            {
+                if (value.ToStringInvariant() == Math.Round(value).ToStringInvariant()) return 0;
+                currentNumberOfDecimals = 1;
+            }
+            if (currentNumberOfDecimals == maxNumberOfDecimals) return maxNumberOfDecimals;
+            var multiplied = value * (decimal) BigInteger.Pow(10, currentNumberOfDecimals);
+            if (Math.Round(multiplied) == multiplied)
+                return currentNumberOfDecimals;
+            return CalculateNumberOfDecimalPlaces(value, maxNumberOfDecimals, currentNumberOfDecimals + 1);
+        }
+
+        //public BigInteger ToWei(decimal amount, BigInteger fromUnit)
+        //{
+
+        //var maxDigits = fromUnit.ToStringInvariant().Length - 1;
+        //var stringAmount = amount.ToStringInvariant("#.#############################", System.Globalization.CultureInfo.InvariantCulture);
+        //if (stringAmount.IndexOf(".") == -1)
+        //{
+        //    return BigIntegerExtensions.ParseInvariant(stringAmount) * fromUnit;
+        //}
+
+        //stringAmount = stringAmount.TrimEnd('0');
+        //var decimalPosition = stringAmount.IndexOf('.');
+        //var decimalPlaces = decimalPosition == -1 ? 0 : stringAmount.Length - decimalPosition - 1;
+
+
+        //if (decimalPlaces > maxDigits)
+        //{
+        //    return BigIntegerExtensions.ParseInvariant(stringAmount.Substring(0, decimalPosition) + stringAmount.Substring(decimalPosition + 1, maxDigits));
+        //}
+
+        //return BigIntegerExtensions.ParseInvariant(stringAmount.Substring(0, decimalPosition) + stringAmount.Substring(decimalPosition + 1).PadRight(maxDigits, '0'));   
+        //}
+    }
+}

--- a/Phantasma.Ethereum/Util/WaitStrategy.cs
+++ b/Phantasma.Ethereum/Util/WaitStrategy.cs
@@ -1,0 +1,21 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+
+namespace Nethereum.Utils
+{
+#if !NET35
+    public class WaitStrategy : IWaitStrategy
+    {
+        private static readonly int[] WaitIntervals = {1000, 2000, 5000, 10000, 15000};
+
+        public Task Apply(uint retryCount)
+        {
+            var intervalMs = retryCount >= WaitIntervals.Length ? 
+                WaitIntervals.Last() : 
+                WaitIntervals[retryCount];
+
+            return Task.Delay(intervalMs);
+        }
+    }
+#endif
+}

--- a/Phantasma.Neo/Phantasma.Neo.csproj
+++ b/Phantasma.Neo/Phantasma.Neo.csproj
@@ -6,7 +6,7 @@
     <OldToolsVersion>Current</OldToolsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="LunarLabs.Parser" Version="1.2.7" />
+    <PackageReference Include="LunarLabs.Parser" Version="1.2.8" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Cryptography\" />

--- a/Phantasma.Numerics/BigInteger.cs
+++ b/Phantasma.Numerics/BigInteger.cs
@@ -1318,6 +1318,11 @@ public void SetBit(uint bitNum)
 
         public static bool IsParsable(string val)
         {
+            if (string.IsNullOrEmpty(val))
+            {
+                return false;
+            }
+
             foreach (var ch in val)
             {
                 if (ch >='0'  && ch <= '9')

--- a/Phantasma.Pay/Phantasma.Pay.csproj
+++ b/Phantasma.Pay/Phantasma.Pay.csproj
@@ -6,7 +6,7 @@
     <OldToolsVersion>Current</OldToolsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="LunarLabs.Parser" Version="1.2.7" />
+    <PackageReference Include="LunarLabs.Parser" Version="1.2.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Phantasma.Cryptography\Phantasma.Cryptography.csproj" />

--- a/Phantasma.RPC/Phantasma.RPC.csproj
+++ b/Phantasma.RPC/Phantasma.RPC.csproj
@@ -5,10 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LunarLabs.Parser" Version="1.2.7" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Phantasma.Blockchain\Phantasma.Blockchain.csproj" />
     <ProjectReference Include="..\Phantasma.Core\Phantasma.Core.csproj" />
     <ProjectReference Include="..\Phantasma.Cryptography\Phantasma.Cryptography.csproj" />

--- a/Phantasma.RocksDB/RocksDB.cs
+++ b/Phantasma.RocksDB/RocksDB.cs
@@ -217,13 +217,16 @@ namespace Phantasma.RocksDB
 
         private void Shutdown()
         {
-
-            logger.Message("Shutting down database...");
-            foreach (var db in _db)
+            if (_db.Count > 0)
             {
-                db.Value.Dispose();
+                logger.Message($"Shutting down databases...");
+                foreach (var db in _db)
+                {
+                    db.Value.Dispose();
+                    _db.Remove(db.Key);
+                }
+                logger.Message("Databases shut down!");
             }
-            logger.Message("Database has been shut down!");
         }
 
     }

--- a/Phantasma.Tests/DBStorageTests.cs
+++ b/Phantasma.Tests/DBStorageTests.cs
@@ -6,8 +6,7 @@ using Phantasma.Core;
 using Phantasma.RocksDB;
 using Phantasma.Storage;
 using System.Threading;
-
-using RocksDbSharp;
+using ConsoleLogger = Phantasma.Core.Log.ConsoleLogger;
 
 namespace Phantasma.Tests
 {
@@ -22,7 +21,7 @@ namespace Phantasma.Tests
         [TestInitialize()]
         public void TestInitialize()
         {
-            _adapterFactory = _adapterFactory = (name) => { return new DBPartition(path + name); };
+            _adapterFactory = _adapterFactory = (name) => { return new DBPartition(new ConsoleLogger(), path + name); };
             _testStorage = new KeyValueStore<string, string>(CreateKeyStoreAdapterTest("test"));
         }
 

--- a/Phantasma.Tests/Phantasma.Tests.csproj
+++ b/Phantasma.Tests/Phantasma.Tests.csproj
@@ -10,9 +10,9 @@
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Phantasma.API\Phantasma.API.csproj" />

--- a/Phantasma.Tests/Phantasma.Tests.csproj
+++ b/Phantasma.Tests/Phantasma.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="Current">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Phantasma.Tests</RootNamespace>
     <FileUpgradeFlags>40</FileUpgradeFlags>
     <UpgradeBackupLocation>C:\code\PhantasmaSpook\Backup\Phantasma.Tests\</UpgradeBackupLocation>

--- a/Phantasma.VM/Instruction.cs
+++ b/Phantasma.VM/Instruction.cs
@@ -31,6 +31,7 @@ namespace Phantasma.VM
                 case Opcode.NOT:
                 case Opcode.NEGATE:
                 case Opcode.ABS:
+                case Opcode.CTX:
                     {
                         AppendRegister(sb, Args[0]);
                         sb.Append(',');
@@ -61,6 +62,7 @@ namespace Phantasma.VM
                 case Opcode.EXTCALL:
                 case Opcode.DEC:
                 case Opcode.INC:
+                case Opcode.SWITCH:
                     {
                         AppendRegister(sb, Args[0]);
                         break;


### PR DESCRIPTION
- Multiple exit events RocksDB:
Due to the fact multiple threads might fire an exit event, make sure the databases are only shut down once, a dispose call on an already shut down db would result in a `segmentation fault` in the RocksDB library.

- Unnecessary dependency in `Phantasma.RPC` package:
Removed `Lunar.Parser` from `Phantasma.RPC` package.