### PR TITLE
Handling for multiple exit events form different threads

### DIFF
--- a/Phantasma.RPC/Phantasma.RPC.csproj
+++ b/Phantasma.RPC/Phantasma.RPC.csproj
@@ -5,10 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LunarLabs.Parser" Version="1.2.7" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Phantasma.Blockchain\Phantasma.Blockchain.csproj" />
     <ProjectReference Include="..\Phantasma.Core\Phantasma.Core.csproj" />
     <ProjectReference Include="..\Phantasma.Cryptography\Phantasma.Cryptography.csproj" />

--- a/Phantasma.RocksDB/RocksDB.cs
+++ b/Phantasma.RocksDB/RocksDB.cs
@@ -217,13 +217,16 @@ namespace Phantasma.RocksDB
 
         private void Shutdown()
         {
-
-            logger.Message("Shutting down database...");
-            foreach (var db in _db)
+            if (_db.Count > 0)
             {
-                db.Value.Dispose();
+                logger.Message($"Shutting down databases...");
+                foreach (var db in _db)
+                {
+                    db.Value.Dispose();
+                    _db.Remove(db.Key);
+                }
+                logger.Message("Databases shut down!");
             }
-            logger.Message("Database has been shut down!");
         }
 
     }


### PR DESCRIPTION
- Multiple exit events RocksDB:
Due to the fact multiple threads might fire an exit event, make sure the databases are only shut down once, a dispose call on an already shut down db would result in a `segmentation fault` in the RocksDB library.

- Unnecessary dependency in `Phantasma.RPC` package:
Removed `Lunar.Parser` from `Phantasma.RPC` package.