### PR TITLE
Fix ToHex() corruption for numbers bigger than 2^32-1

### DIFF
--- a/Phantasma.Numerics/BigInteger.cs
+++ b/Phantasma.Numerics/BigInteger.cs
@@ -311,9 +311,11 @@ namespace Phantasma.Numerics
         {
             string result = "";
 
-            foreach (var digit in Data)
+            // Whole code is written to be compatible with little-endian arch only.
+            // Here we should process digits in reverse order.
+            for (var i = Data.Length - 1; i >= 0; i--)
             {
-                result += digit.ToString("x8");
+                result += Data[i].ToString("x8");
             }
 
             result = result.TrimStart('0');


### PR DESCRIPTION
Whole bigint code is written to be compatible with little-endian arc only.
ToHex() was written for big-endian arc.